### PR TITLE
Remove generated code warnings and other fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,18 @@
-# The C implementation is generated using Python scripts
-language: python
+language: c
 
 script:
   - make
+
+compiler:
+  - clang
+  - gcc
+
+os:
+  - linux
+  - osx
+
+matrix:
+  fast_finish: true
 
 branches:
   only:

--- a/include/f_field.h
+++ b/include/f_field.h
@@ -7,9 +7,6 @@
  *   Released under the MIT License.  See LICENSE.txt for license information.
  *
  * @brief Field-specific code for 2^255 - 19.
- *
- * @warning This file was automatically generated in Python.
- * Please do not edit it.
  */
 
 #ifndef __P25519_F_FIELD_H__

--- a/include/ristretto255/point.h
+++ b/include/ristretto255/point.h
@@ -7,9 +7,6 @@
  *   Released under the MIT License.  See LICENSE.txt for license information.
  *
  * @brief A group of prime order p, based on Curve25519.
- *
- * @warning This file was automatically generated in Python.
- * Please do not edit it.
  */
 
 #ifndef __RISTRETTO255_POINT_H__
@@ -64,7 +61,7 @@ typedef struct ristretto255_point_s {
 struct ristretto255_precomputed_s;
 
 /** Precomputed table based on a point.  Can be trivial implementation. */
-typedef struct ristretto255_precomputed_s ristretto255_precomputed_s; 
+typedef struct ristretto255_precomputed_s ristretto255_precomputed_s;
 
 /** Size and alignment of precomputed point tables. */
 RISTRETTO_API_VIS extern const size_t ristretto255_sizeof_precomputed_s, ristretto255_alignof_precomputed_s;
@@ -140,7 +137,7 @@ void RISTRETTO_API_VIS ristretto255_scalar_decode_long (
     const unsigned char *ser,
     size_t ser_len
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
-    
+
 /**
  * @brief Serialize a scalar to wire format.
  *
@@ -151,7 +148,7 @@ void RISTRETTO_API_VIS ristretto255_scalar_encode (
     unsigned char ser[RISTRETTO255_SCALAR_BYTES],
     const ristretto255_scalar_t s
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE RISTRETTO_NOINLINE;
-        
+
 /**
  * @brief Add two scalars.  The scalars may use the same memory.
  * @param [in] a One scalar.
@@ -170,7 +167,7 @@ void RISTRETTO_API_VIS ristretto255_scalar_add (
  * @param [in] b Another scalar.
  * @retval RISTRETTO_TRUE The scalars are equal.
  * @retval RISTRETTO_FALSE The scalars are not equal.
- */    
+ */
 ristretto_bool_t RISTRETTO_API_VIS ristretto255_scalar_eq (
     const ristretto255_scalar_t a,
     const ristretto255_scalar_t b
@@ -181,7 +178,7 @@ ristretto_bool_t RISTRETTO_API_VIS ristretto255_scalar_eq (
  * @param [in] a One scalar.
  * @param [in] b Another scalar.
  * @param [out] out a-b.
- */  
+ */
 void RISTRETTO_API_VIS ristretto255_scalar_sub (
     ristretto255_scalar_t out,
     const ristretto255_scalar_t a,
@@ -193,13 +190,13 @@ void RISTRETTO_API_VIS ristretto255_scalar_sub (
  * @param [in] a One scalar.
  * @param [in] b Another scalar.
  * @param [out] out a*b.
- */  
+ */
 void RISTRETTO_API_VIS ristretto255_scalar_mul (
     ristretto255_scalar_t out,
     const ristretto255_scalar_t a,
     const ristretto255_scalar_t b
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
-        
+
 /**
 * @brief Halve a scalar.  The scalars may use the same memory.
 * @param [in] a A scalar.
@@ -215,7 +212,7 @@ void RISTRETTO_API_VIS ristretto255_scalar_halve (
  * @param [in] a A scalar.
  * @param [out] out 1/a.
  * @return RISTRETTO_SUCCESS The input is nonzero.
- */  
+ */
 ristretto_error_t RISTRETTO_API_VIS ristretto255_scalar_invert (
     ristretto255_scalar_t out,
     const ristretto255_scalar_t a
@@ -238,7 +235,7 @@ static inline void RISTRETTO_NONNULL ristretto255_scalar_copy (
  * @brief Set a scalar to an unsigned 64-bit integer.
  * @param [in] a An integer.
  * @param [out] out Will become equal to a.
- */  
+ */
 void RISTRETTO_API_VIS ristretto255_scalar_set_unsigned (
     ristretto255_scalar_t out,
     uint64_t a
@@ -344,7 +341,7 @@ void RISTRETTO_API_VIS ristretto255_point_sub (
     const ristretto255_point_t a,
     const ristretto255_point_t b
 ) RISTRETTO_NONNULL;
-    
+
 /**
  * @brief Negate a point to produce another point.  The input
  * and output points can use the same memory.
@@ -446,7 +443,7 @@ void RISTRETTO_API_VIS ristretto255_point_double_scalarmul (
     const ristretto255_point_t base2,
     const ristretto255_scalar_t scalar2
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
-    
+
 /**
  * Multiply one base point by two scalars:
  *
@@ -583,7 +580,7 @@ void RISTRETTO_API_VIS ristretto255_point_debugging_pscale (
  * (mod q) results in the negative point.  This is the same as Elligator.
  *
  * This function isn't quite indifferentiable from a random oracle.
- * However, it is suitable for many protocols, including SPEKE and SPAKE2 EE. 
+ * However, it is suitable for many protocols, including SPEKE and SPAKE2 EE.
  * Furthermore, calling it twice with independent seeds and adding the results
  * is indifferentiable from a random oracle.
  *
@@ -603,7 +600,7 @@ ristretto255_point_from_hash_nonuniform (
  *
  * @param [in] hashed_data Output of some hash function.
  * @param [out] pt The data hashed to the curve.
- */ 
+ */
 void RISTRETTO_API_VIS ristretto255_point_from_hash_uniform (
     ristretto255_point_t pt,
     const unsigned char hashed_data[2*RISTRETTO255_HASH_BYTES]

--- a/src/elligator.c
+++ b/src/elligator.c
@@ -19,8 +19,7 @@
 #define COFACTOR 8
 static const int EDWARDS_D = -121665;
 
-#define RISTRETTO_FACTOR RISTRETTO255_FACTOR
-extern const gf RISTRETTO_FACTOR;
+extern const gf RISTRETTO255_FACTOR;
 
 /* End of template stuff */
 extern mask_t ristretto255_deisogenize (
@@ -133,9 +132,9 @@ ristretto255_invert_elligator_nonuniform (
     gf_cond_sel(c,c,ONE,is_identity & sgn_s &~ sgn_altx);
 #elif IMAGINE_TWIST
     /* Terrible, terrible special casing due to lots of 0/0 is deisogenize
-     * Basically we need to generate -D and +- i*RISTRETTO_FACTOR
+     * Basically we need to generate -D and +- i*RISTRETTO255_FACTOR
      */
-    gf_mul_i(a,RISTRETTO_FACTOR);
+    gf_mul_i(a,RISTRETTO255_FACTOR);
     gf_cond_sel(b,b,ONE,is_identity);
     gf_cond_neg(a,sgn_altx);
     gf_cond_sel(c,c,a,is_identity & sgn_ed_T);

--- a/src/elligator.c
+++ b/src/elligator.c
@@ -7,9 +7,6 @@
  *   Released under the MIT License.  See LICENSE.txt for license information.
  *
  * @brief Elligator high-level functions.
- *
- * @warning This file was automatically generated in Python.
- * Please do not edit it.
  */
 #include "word.h"
 #include "field.h"
@@ -53,21 +50,21 @@ void ristretto255_point_from_hash_nonuniform (
     gf_add(a,b,ONE);
     gf_sub(b,b,r);
     gf_mul(c,a,b);
-    
+
     /* compute N := (r+1)(a-2d) */
     gf_add(a,r,ONE);
     gf_mulw(N,a,1-2*EDWARDS_D);
-    
+
     /* e = +-sqrt(1/ND) or +-r0 * sqrt(qnr/ND) */
     gf_mul(a,c,N);
     mask_t square = gf_isr(b,a);
     gf_cond_sel(c,r0,ONE,square); /* r? = square ? 1 : r0 */
     gf_mul(e,b,c);
-    
+
     /* s@a = +-|N.e| */
     gf_mul(a,N,e);
     gf_cond_neg(a,gf_lobit(a) ^ ~square);
-    
+
     /* t@b = -+ cN(r-1)((a-2d)e)^2 - 1 */
     gf_mulw(c,e,1-2*EDWARDS_D); /* (a-2d)e */
     gf_sqr(b,c);
@@ -82,7 +79,7 @@ void ristretto255_point_from_hash_nonuniform (
     gf_mul(c,a,SQRT_MINUS_ONE);
     gf_copy(a,c);
 #endif
-    
+
     gf_sqr(c,a); /* s^2 */
     gf_add(a,a,a); /* 2s */
     gf_add(e,c,ONE);
@@ -91,7 +88,7 @@ void ristretto255_point_from_hash_nonuniform (
     gf_sub(a,ONE,c);
     gf_mul(p->y,e,a); /* (1+s^2)(1-s^2) */
     gf_mul(p->z,a,b); /* (1-s^2)t */
-    
+
     assert(ristretto255_point_valid(p));
 }
 
@@ -129,7 +126,7 @@ ristretto255_invert_elligator_nonuniform (
         sgn_ed_T = -(hint>>3 & 1);
     gf a,b,c;
     ristretto255_deisogenize(a,b,c,p,sgn_s,sgn_altx,sgn_ed_T);
-    
+
     mask_t is_identity = gf_eq(p->t,ZERO);
 #if COFACTOR==4
     gf_cond_sel(b,b,ONE,is_identity & sgn_altx);
@@ -148,7 +145,7 @@ ristretto255_invert_elligator_nonuniform (
 #else
 #error "Different special-casing goes here!"
 #endif
-    
+
 #if IMAGINE_TWIST
     gf_mulw(a,b,-EDWARDS_D);
 #else
@@ -163,19 +160,19 @@ ristretto255_invert_elligator_nonuniform (
     mask_t succ = gf_isr(c,b);
     succ |= gf_eq(b,ZERO);
     gf_mul(b,c,a);
-    
+
 #if 255 == 8*SER_BYTES + 1 /* p521. */
 #error "this won't work because it needs to adjust high bit, not low bit"
     sgn_r0 = 0;
 #endif
-    
+
     gf_cond_neg(b, sgn_r0^gf_lobit(b));
     /* Eliminate duplicate values for identity ... */
     succ &= ~(gf_eq(b,ZERO) & (sgn_r0 | sgn_s));
     // #if COFACTOR == 8
     //     succ &= ~(is_identity & sgn_ed_T); /* NB: there are no preimages of rotated identity. */
     // #endif
-    
+
     #if 255 == 8*SER_BYTES + 1 /* p521 */
         gf_serialize(recovered_hash,b,0);
     #else

--- a/src/f_generic.c
+++ b/src/f_generic.c
@@ -7,16 +7,13 @@
  *   Released under the MIT License.  See LICENSE.txt for license information.
  *
  * @brief Generic arithmetic which has to be compiled per field.
- *
- * @warning This file was automatically generated in Python.
- * Please do not edit it.
  */
 #include "field.h"
 
 static const gf MODULUS = {FIELD_LITERAL(
     0x7ffffffffffed, 0x7ffffffffffff, 0x7ffffffffffff, 0x7ffffffffffff, 0x7ffffffffffff
 )};
-    
+
 #if P_MOD_8 == 5
     const gf SQRT_MINUS_ONE = {FIELD_LITERAL(
         0x61b274a0ea0b0, 0x0d5a5fc8f189d, 0x7ef5e9cbd0c60, 0x78595a6804c9e, 0x2b8324804fc1d
@@ -29,7 +26,7 @@ void gf_serialize (uint8_t serial[SER_BYTES], const gf x, int with_hibit) {
     gf_copy(red, x);
     gf_strong_reduce(red);
     if (!with_hibit) { assert(gf_hibit(red) == 0); }
-    
+
     unsigned int j=0, fill=0;
     dword_t buffer = 0;
     UNROLL for (unsigned int i=0; i<(with_hibit ? X_SER_BYTES : SER_BYTES); i++) {

--- a/src/ristretto.c
+++ b/src/ristretto.c
@@ -58,8 +58,7 @@ static const scalar_t point_scalarmul_adjustment = {{{
     SC_LIMB(0x977f4a4775473484), SC_LIMB(0x6de72ae98b3ab623), SC_LIMB(0xffffffffffffffff), SC_LIMB(0x0fffffffffffffff)
 }}};
 
-#define RISTRETTO_FACTOR RISTRETTO255_FACTOR
-const gf RISTRETTO_FACTOR = {FIELD_LITERAL(
+const gf RISTRETTO255_FACTOR = {FIELD_LITERAL(
     0x702557fa2bf03, 0x514b7d1a82cc6, 0x7f89efd8b43a7, 0x1aef49ec23700, 0x079376fa30500
 )};
 
@@ -177,7 +176,7 @@ void ristretto255_deisogenize (
     gf_mulw(t2,t1,-1-TWISTED_D); /* -x^2 * (a-d) * num */
     gf_isr(t1,t2);    /* t1 = isr */
     gf_mul(t2,t1,t3); /* t2 = ratio */
-    gf_mul(t4,t2,RISTRETTO_FACTOR);
+    gf_mul(t4,t2,RISTRETTO255_FACTOR);
     mask_t negx = gf_lobit(t4) ^ toggle_altx;
     gf_cond_neg(t2, negx);
     gf_mul(t3,t2,p->z);
@@ -203,7 +202,7 @@ void ristretto255_deisogenize (
     gf_mulw(t1,t4,-1-TWISTED_D);
     gf_isr(t4,t1);         /* isqrt(num*(a-d)*den^2) */
     gf_mul(t1,t2,t4);
-    gf_mul(t2,t1,RISTRETTO_FACTOR); /* t2 = "iden" in ristretto.sage */
+    gf_mul(t2,t1,RISTRETTO255_FACTOR); /* t2 = "iden" in ristretto.sage */
     gf_mul(t1,t3,t4);                 /* t1 = "inum" in ristretto.sage */
 
     /* Calculate altxy = iden*inum*i*t^2*(d-a) */
@@ -219,7 +218,7 @@ void ristretto255_deisogenize (
     gf_mul_i(t4,p->x);
     gf_cond_sel(t4,p->y,t4,rotate);  /* t4 = "fac" = ix if rotate, else y */
 
-    gf_mul_i(t5,RISTRETTO_FACTOR); /* t5 = imi */
+    gf_mul_i(t5,RISTRETTO255_FACTOR); /* t5 = imi */
     gf_mul(t3,t5,t2);                /* iden * imi */
     gf_mul(t2,t5,t1);
     gf_mul(t5,t2,p->t);              /* "altx" = iden*imi*t */
@@ -278,14 +277,14 @@ ristretto_error_t ristretto255_point_decode (
     gf_add(tmp2,tmp2,tmp2);        /* 2*s*isr*den */
     gf_mul(tmp,tmp2,isr);          /* 2*s*isr^2*den */
     gf_mul(p->x,tmp,num);          /* 2*s*isr^2*den*num */
-    gf_mul(tmp,tmp2,RISTRETTO_FACTOR); /* 2*s*isr*den*magic */
+    gf_mul(tmp,tmp2,RISTRETTO255_FACTOR); /* 2*s*isr*den*magic */
     gf_cond_neg(p->x,gf_lobit(tmp)); /* flip x */
 
 #if COFACTOR==8
     /* Additionally check y != 0 and x*y*isomagic nonegative */
     succ &= ~gf_eq(p->y,ZERO);
     gf_mul(tmp,p->x,p->y);
-    gf_mul(tmp2,tmp,RISTRETTO_FACTOR);
+    gf_mul(tmp2,tmp,RISTRETTO255_FACTOR);
     succ &= ~gf_lobit(tmp2);
 #endif
 
@@ -1104,7 +1103,7 @@ void ristretto255_point_mul_by_ratio_and_encode_like_eddsa (
         gf_mul ( y, u, t ); // (x^2+y^2)(2z^2-y^2+x^2)
         gf_mul ( u, z, t );
         gf_copy( z, u );
-        gf_mul ( u, x, RISTRETTO_FACTOR );
+        gf_mul ( u, x, RISTRETTO255_FACTOR );
 #if IMAGINE_TWIST
         gf_mul_i( x, u );
 #else
@@ -1216,7 +1215,7 @@ ristretto_error_t ristretto255_point_decode_like_eddsa_and_mul_by_ratio (
         gf_add ( p->z, p->x, p->x );
         gf_sub ( c, p->z, p->t ); // 2z^2 - y^2 + x^2
         gf_div_i ( a, c );
-        gf_mul ( c, a, RISTRETTO_FACTOR );
+        gf_mul ( c, a, RISTRETTO255_FACTOR );
         gf_mul ( p->x, b, p->t); // (2xy)(y^2-x^2)
         gf_mul ( p->z, p->t, c ); // (y^2-x^2)sd(2z^2 - y^2 + x^2)
         gf_mul ( p->y, d, c ); // (y^2+x^2)sd(2z^2 - y^2 + x^2)

--- a/src/ristretto.c
+++ b/src/ristretto.c
@@ -7,9 +7,6 @@
  *   Released under the MIT License.  See LICENSE.txt for license information.
  *
  * @brief Ristretto255 high-level functions.
- *
- * @warning This file was automatically generated in Python.
- * Please do not edit it.
  */
 #define _XOPEN_SOURCE 600 /* for posix_memalign */
 #include "word.h"
@@ -97,7 +94,7 @@ const gf RISTRETTO_FACTOR = {FIELD_LITERAL(
 #error "Currently require IMAGINE_TWIST (and thus p=5 mod 8) for cofactor 8"
         /* OK, but why?
          * Two reasons: #1: There are bugs when COFACTOR == && IMAGINE_TWIST
-         # #2: 
+         # #2:
          */
 #endif
 
@@ -108,7 +105,7 @@ const gf RISTRETTO_FACTOR = {FIELD_LITERAL(
 #if (COFACTOR != 8) && (COFACTOR != 4)
     #error "COFACTOR must be 4 or 8"
 #endif
- 
+
 #if IMAGINE_TWIST
     extern const gf SQRT_MINUS_ONE;
 #endif
@@ -171,7 +168,7 @@ void ristretto255_deisogenize (
     (void)toggle_rotation; /* Only applies to cofactor 8 */
     gf t1;
     gf_s *t2 = s, *t3=inv_el_sum, *t4=inv_el_m1;
-    
+
     gf_add(t1,p->x,p->t);
     gf_sub(t2,p->x,p->t);
     gf_mul(t3,t1,t2); /* t3 = num */
@@ -193,7 +190,7 @@ void ristretto255_deisogenize (
     gf_copy(inv_el_m1,p->x);
     gf_cond_neg(inv_el_m1,~lobs^negx^toggle_s);
     gf_add(inv_el_m1,inv_el_m1,p->t);
-    
+
 #elif COFACTOR == 8 && IMAGINE_TWIST
     /* More complicated because of rotation */
     gf t1,t2,t3,t4,t5;
@@ -216,27 +213,27 @@ void ristretto255_deisogenize (
     gf_mul(t4,t3,p->t);
     gf_mulw(t3,t4,TWISTED_D+1);      /* iden*inum*i*t^2*(d-1) */
     mask_t rotate = toggle_rotation ^ gf_lobit(t3);
-    
+
     /* Rotate if altxy is negative */
     gf_cond_swap(t1,t2,rotate);
     gf_mul_i(t4,p->x);
     gf_cond_sel(t4,p->y,t4,rotate);  /* t4 = "fac" = ix if rotate, else y */
-    
+
     gf_mul_i(t5,RISTRETTO_FACTOR); /* t5 = imi */
     gf_mul(t3,t5,t2);                /* iden * imi */
     gf_mul(t2,t5,t1);
     gf_mul(t5,t2,p->t);              /* "altx" = iden*imi*t */
     mask_t negx = gf_lobit(t5) ^ toggle_altx;
-    
+
     gf_cond_neg(t1,negx^rotate);
     gf_mul(t2,t1,p->z);
     gf_add(t2,t2,ONE);
     gf_mul(inv_el_sum,t2,t4);
     gf_mul(s,inv_el_sum,t3);
-    
+
     mask_t negs = gf_lobit(s);
     gf_cond_neg(s,negs);
-    
+
     mask_t negz = ~negs ^ toggle_s ^ negx;
     gf_copy(inv_el_m1,p->z);
     gf_cond_neg(inv_el_m1,negz);
@@ -259,11 +256,11 @@ ristretto_error_t ristretto255_point_decode (
 ) {
     gf s, s2, num, tmp;
     gf_s *tmp2=s2, *ynum=p->z, *isr=p->x, *den=p->t;
-    
+
     mask_t succ = gf_deserialize(s, ser, 1, 0);
     succ &= bool_to_mask(allow_identity) | ~gf_eq(s, ZERO);
     succ &= ~gf_lobit(s);
-    
+
     gf_sqr(s2,s);                  /* s^2 = -as^2 */
 #if IMAGINE_TWIST
     gf_sub(s2,ZERO,s2);            /* -as^2 */
@@ -283,7 +280,7 @@ ristretto_error_t ristretto255_point_decode (
     gf_mul(p->x,tmp,num);          /* 2*s*isr^2*den*num */
     gf_mul(tmp,tmp2,RISTRETTO_FACTOR); /* 2*s*isr*den*magic */
     gf_cond_neg(p->x,gf_lobit(tmp)); /* flip x */
-    
+
 #if COFACTOR==8
     /* Additionally check y != 0 and x*y*isomagic nonegative */
     succ &= ~gf_eq(p->y,ZERO);
@@ -300,7 +297,7 @@ ristretto_error_t ristretto255_point_decode (
     /* Fill in z and t */
     gf_copy(p->z,ONE);
     gf_mul(p->t,p->x,p->y);
-    
+
     assert(ristretto255_point_valid(p) | ~succ);
     return ristretto_succeed_if(mask_to_bool(succ));
 }
@@ -336,7 +333,7 @@ void ristretto255_point_sub (
     gf_mul ( p->y, a, b );
     gf_mul ( p->t, b, c );
 }
-    
+
 void ristretto255_point_add (
     point_t p,
     const point_t q,
@@ -528,7 +525,7 @@ prepare_fixed_window(
     point_t tmp;
     pniels_t pn;
     int i;
-    
+
     point_double_internal(tmp, b, 0);
     pt_to_pniels(pn, tmp);
     pt_to_pniels(multiples[0], b);
@@ -537,7 +534,7 @@ prepare_fixed_window(
         add_pniels_to_pt(tmp, pn, 0);
         pt_to_pniels(multiples[i], tmp);
     }
-    
+
     ristretto_bzero(pn,sizeof(pn));
     ristretto_bzero(tmp,sizeof(tmp));
 }
@@ -552,11 +549,11 @@ void ristretto255_point_scalarmul (
         WINDOW_MASK = (1<<WINDOW)-1,
         WINDOW_T_MASK = WINDOW_MASK >> 1,
         NTABLE = 1<<(WINDOW-1);
-        
+
     scalar_t scalar1x;
     ristretto255_scalar_add(scalar1x, scalar, point_scalarmul_adjustment);
     ristretto255_scalar_halve(scalar1x,scalar1x);
-    
+
     /* Set up a precomputed table with odd multiples of b. */
     pniels_t pn, multiples[1<<((int)(RISTRETTO_WINDOW_BITS)-1)];  // == NTABLE (MSVC compatibility issue)
     point_t tmp;
@@ -575,7 +572,7 @@ void ristretto255_point_scalarmul (
         bits &= WINDOW_MASK;
         mask_t inv = (bits>>(WINDOW-1))-1;
         bits ^= inv;
-    
+
         /* Add in from table.  Compute t only on last iteration. */
         constant_time_lookup(pn, multiples, sizeof(pn), NTABLE, bits & WINDOW_T_MASK);
         cond_neg_niels(pn->n, inv);
@@ -593,10 +590,10 @@ void ristretto255_point_scalarmul (
             add_pniels_to_pt(tmp, pn, i ? -1 : 0);
         }
     }
-    
+
     /* Write out the answer */
     ristretto255_point_copy(a,tmp);
-    
+
     ristretto_bzero(scalar1x,sizeof(scalar1x));
     ristretto_bzero(pn,sizeof(pn));
     ristretto_bzero(multiples,sizeof(multiples));
@@ -609,8 +606,8 @@ void ristretto255_point_double_scalarmul (
     const scalar_t scalarb,
     const point_t c,
     const scalar_t scalarc
-) {    
-    
+) {
+
     const int WINDOW = RISTRETTO_WINDOW_BITS,
         WINDOW_MASK = (1<<WINDOW)-1,
         WINDOW_T_MASK = WINDOW_MASK >> 1,
@@ -621,12 +618,12 @@ void ristretto255_point_double_scalarmul (
     ristretto255_scalar_halve(scalar1x,scalar1x);
     ristretto255_scalar_add(scalar2x, scalarc, point_scalarmul_adjustment);
     ristretto255_scalar_halve(scalar2x,scalar2x);
-    
+
     /* Set up a precomputed table with odd multiples of b. */
     pniels_t pn, multiples1[1<<((int)(RISTRETTO_WINDOW_BITS)-1)], multiples2[1<<((int)(RISTRETTO_WINDOW_BITS)-1)];
     // Array size above equal NTABLE (MSVC compatibility issue)
     point_t tmp;
-    prepare_fixed_window(multiples1, b, NTABLE);  
+    prepare_fixed_window(multiples1, b, NTABLE);
     prepare_fixed_window(multiples2, c, NTABLE);
 
     /* Initialize. */
@@ -647,7 +644,7 @@ void ristretto255_point_double_scalarmul (
         mask_t inv2 = (bits2>>(WINDOW-1))-1;
         bits1 ^= inv1;
         bits2 ^= inv2;
-    
+
         /* Add in from table.  Compute t only on last iteration. */
         constant_time_lookup(pn, multiples1, sizeof(pn), NTABLE, bits1 & WINDOW_T_MASK);
         cond_neg_niels(pn->n, inv1);
@@ -668,10 +665,10 @@ void ristretto255_point_double_scalarmul (
         cond_neg_niels(pn->n, inv2);
         add_pniels_to_pt(tmp, pn, i?-1:0);
     }
-    
+
     /* Write out the answer */
     ristretto255_point_copy(a,tmp);
-    
+
 
     ristretto_bzero(scalar1x,sizeof(scalar1x));
     ristretto_bzero(scalar2x,sizeof(scalar2x));
@@ -688,7 +685,7 @@ void ristretto255_point_dual_scalarmul (
     const scalar_t scalar1,
     const scalar_t scalar2
 ) {
-    
+
     const int WINDOW = RISTRETTO_WINDOW_BITS,
         WINDOW_MASK = (1<<WINDOW)-1,
         WINDOW_T_MASK = WINDOW_MASK >> 1,
@@ -700,30 +697,30 @@ void ristretto255_point_dual_scalarmul (
     ristretto255_scalar_halve(scalar1x,scalar1x);
     ristretto255_scalar_add(scalar2x, scalar2, point_scalarmul_adjustment);
     ristretto255_scalar_halve(scalar2x,scalar2x);
-    
+
     /* Set up a precomputed table with odd multiples of b. */
     point_t multiples1[1<<((int)(RISTRETTO_WINDOW_BITS)-1)], multiples2[1<<((int)(RISTRETTO_WINDOW_BITS)-1)], working, tmp;
     // Array sizes above equal NTABLE (MSVC compatibility issue)
 
     pniels_t pn;
-    
+
     ristretto255_point_copy(working, b);
 
     /* Initialize. */
     int i,j;
-    
+
     for (i=0; i<NTABLE; i++) {
         ristretto255_point_copy(multiples1[i], ristretto255_point_identity);
         ristretto255_point_copy(multiples2[i], ristretto255_point_identity);
     }
 
-    for (i=0; i<SCALAR_BITS; i+=WINDOW) {   
+    for (i=0; i<SCALAR_BITS; i+=WINDOW) {
         if (i) {
             for (j=0; j<WINDOW-1; j++)
                 point_double_internal(working, working, -1);
             point_double_internal(working, working, 0);
         }
-        
+
         /* Fetch another block of bits */
         word_t bits1 = scalar1x->limb[i/WBITS] >> (i%WBITS),
                bits2 = scalar2x->limb[i/WBITS] >> (i%WBITS);
@@ -737,7 +734,7 @@ void ristretto255_point_dual_scalarmul (
         mask_t inv2 = (bits2>>(WINDOW-1))-1;
         bits1 ^= inv1;
         bits2 ^= inv2;
-        
+
         pt_to_pniels(pn, working);
 
         constant_time_lookup(tmp, multiples1, sizeof(tmp), NTABLE, bits1 & WINDOW_T_MASK);
@@ -745,26 +742,26 @@ void ristretto255_point_dual_scalarmul (
         /* add_pniels_to_pt(multiples1[bits1 & WINDOW_T_MASK], pn, 0); */
         add_pniels_to_pt(tmp, pn, 0);
         constant_time_insert(multiples1, tmp, sizeof(tmp), NTABLE, bits1 & WINDOW_T_MASK);
-        
-        
+
+
         constant_time_lookup(tmp, multiples2, sizeof(tmp), NTABLE, bits2 & WINDOW_T_MASK);
         cond_neg_niels(pn->n, inv1^inv2);
         /* add_pniels_to_pt(multiples2[bits2 & WINDOW_T_MASK], pn, 0); */
         add_pniels_to_pt(tmp, pn, 0);
         constant_time_insert(multiples2, tmp, sizeof(tmp), NTABLE, bits2 & WINDOW_T_MASK);
     }
-    
+
     if (NTABLE > 1) {
         ristretto255_point_copy(working, multiples1[NTABLE-1]);
         ristretto255_point_copy(tmp    , multiples2[NTABLE-1]);
-    
+
         for (i=NTABLE-1; i>1; i--) {
             ristretto255_point_add(multiples1[i-1], multiples1[i-1], multiples1[i]);
             ristretto255_point_add(multiples2[i-1], multiples2[i-1], multiples2[i]);
             ristretto255_point_add(working, working, multiples1[i-1]);
             ristretto255_point_add(tmp,     tmp,     multiples2[i-1]);
         }
-    
+
         ristretto255_point_add(multiples1[0], multiples1[0], multiples1[1]);
         ristretto255_point_add(multiples2[0], multiples2[0], multiples2[1]);
         point_double_internal(working, working, 0);
@@ -791,7 +788,7 @@ ristretto_bool_t ristretto255_point_eq ( const point_t p, const point_t q ) {
     gf_mul ( a, p->y, q->x );
     gf_mul ( b, q->y, p->x );
     mask_t succ = gf_eq(a,b);
-    
+
     #if (COFACTOR == 8)
         gf_mul ( a, p->y, q->y );
         gf_mul ( b, q->x, p->x );
@@ -802,12 +799,12 @@ ristretto_bool_t ristretto255_point_eq ( const point_t p, const point_t q ) {
             * But because of the *i twist, it's actually
             * (x,y) <-> (iy,ix)
             */
-    
+
            /* No code, just a comment. */
         #endif
         succ |= gf_eq(a,b);
     #endif
-    
+
     return mask_to_bool(succ);
 }
 
@@ -875,7 +872,7 @@ static void gf_batch_invert (
 ) {
     gf t1;
     assert(n>1);
-  
+
     gf_copy(out[1], in[0]);
     int i;
     for (i=1; i<(int) (n-1); i++) {
@@ -907,34 +904,34 @@ static void batch_normalize_niels (
         gf_mul(product, table[i]->a, zis[i]);
         gf_strong_reduce(product);
         gf_copy(table[i]->a, product);
-        
+
         gf_mul(product, table[i]->b, zis[i]);
         gf_strong_reduce(product);
         gf_copy(table[i]->b, product);
-        
+
         gf_mul(product, table[i]->c, zis[i]);
         gf_strong_reduce(product);
         gf_copy(table[i]->c, product);
     }
-    
+
     ristretto_bzero(product,sizeof(product));
 }
 
 void ristretto255_precompute (
     precomputed_s *table,
     const point_t base
-) { 
+) {
     const unsigned int n = COMBS_N, t = COMBS_T, s = COMBS_S;
     assert(n*t*s >= SCALAR_BITS);
-  
+
     point_t working, start, doubles[COMBS_T-1];
     ristretto255_point_copy(working, base);
     pniels_t pn_tmp;
-  
+
     gf zs[(unsigned int)(COMBS_N)<<(unsigned int)(COMBS_T-1)], zis[(unsigned int)(COMBS_N)<<(unsigned int)(COMBS_T-1)];
-  
+
     unsigned int i,j,k;
-    
+
     /* Compute n tables */
     for (i=0; i<n; i++) {
 
@@ -960,13 +957,13 @@ void ristretto255_precompute (
             pt_to_pniels(pn_tmp, start);
             memcpy(table->table[idx], pn_tmp->n, sizeof(pn_tmp->n));
             gf_copy(zs[idx], pn_tmp->z);
-			
+
             if (j >= (1u<<(t-1)) - 1) break;
             int delta = (j+1) ^ ((j+1)>>1) ^ gray;
 
             for (k=0; delta>1; k++)
                 delta >>=1;
-            
+
             if (gray & (1<<k)) {
                 ristretto255_point_add(start, start, doubles[k]);
             } else {
@@ -974,9 +971,9 @@ void ristretto255_precompute (
             }
         }
     }
-    
+
     batch_normalize_niels(table->table,(const gf *)zs,zis,n<<(t-1));
-    
+
     ristretto_bzero(zs,sizeof(zs));
     ristretto_bzero(zis,sizeof(zis));
     ristretto_bzero(pn_tmp,sizeof(pn_tmp));
@@ -1003,26 +1000,26 @@ void ristretto255_precomputed_scalarmul (
     int i;
     unsigned j,k;
     const unsigned int n = COMBS_N, t = COMBS_T, s = COMBS_S;
-    
+
     scalar_t scalar1x;
     ristretto255_scalar_add(scalar1x, scalar, precomputed_scalarmul_adjustment);
     ristretto255_scalar_halve(scalar1x,scalar1x);
-    
+
     niels_t ni;
-    
+
     for (i=s-1; i>=0; i--) {
         if (i != (int)s-1) point_double_internal(out,out,0);
-        
+
         for (j=0; j<n; j++) {
             int tab = 0;
-         
+
             for (k=0; k<t; k++) {
                 unsigned int bit = i + s*(k + j*t);
                 if (bit < SCALAR_BITS) {
                     tab |= (scalar1x->limb[bit/WBITS] >> (bit%WBITS) & 1) << k;
                 }
             }
-            
+
             mask_t invert = (tab>>(t-1))-1;
             tab ^= invert;
             tab &= (1<<(t-1)) - 1;
@@ -1037,7 +1034,7 @@ void ristretto255_precomputed_scalarmul (
             }
         }
     }
-    
+
     ristretto_bzero(ni,sizeof(ni));
     ristretto_bzero(scalar1x,sizeof(scalar1x));
 }
@@ -1073,7 +1070,7 @@ void ristretto255_point_mul_by_ratio_and_encode_like_eddsa (
     uint8_t enc[RISTRETTO255_PUBLIC_BYTES],
     const point_t p
 ) {
-    
+
     /* The point is now on the twisted curve.  Move it to untwisted. */
     gf x, y, z, t;
     point_t q;
@@ -1082,7 +1079,7 @@ void ristretto255_point_mul_by_ratio_and_encode_like_eddsa (
 #else
     ristretto255_point_copy(q,p);
 #endif
-    
+
 #if EDDSA_USE_SIGMA_ISOGENY
     {
         /* Use 4-isogeny like ed25519:
@@ -1136,7 +1133,7 @@ void ristretto255_point_mul_by_ratio_and_encode_like_eddsa (
         gf_sub ( y, y, u );
         gf_sub ( z, t, x );
         gf_sqr ( x, q->z );
-        gf_add ( t, x, x); 
+        gf_add ( t, x, x);
         gf_sub ( t, t, z);
         gf_mul ( x, t, y );
         gf_mul ( y, z, u );
@@ -1148,7 +1145,7 @@ void ristretto255_point_mul_by_ratio_and_encode_like_eddsa (
     gf_invert(z,z,1);
     gf_mul(t,x,z);
     gf_mul(x,y,z);
-    
+
     /* Encode */
     enc[RISTRETTO255_PRIVATE_BYTES-1] = 0;
     gf_serialize(enc, x, 1);
@@ -1171,7 +1168,7 @@ ristretto_error_t ristretto255_point_decode_like_eddsa_and_mul_by_ratio (
 
     mask_t low = ~word_is_zero(enc2[RISTRETTO255_PRIVATE_BYTES-1] & 0x80);
     enc2[RISTRETTO255_PRIVATE_BYTES-1] &= ~0x80;
-    
+
     mask_t succ = gf_deserialize(p->y, enc2, 1, 0);
 #if 7 == 0
     succ &= word_is_zero(enc2[RISTRETTO255_PRIVATE_BYTES-1]);
@@ -1187,14 +1184,14 @@ ristretto_error_t ristretto255_point_decode_like_eddsa_and_mul_by_ratio (
         gf_mulw(p->t,p->x,EDWARDS_D); /* dy^2 */
     #endif
     gf_sub(p->t,ONE,p->t); /* denom = 1-dy^2 or 1-d + dy^2 */
-    
+
     gf_mul(p->x,p->z,p->t);
     succ &= gf_isr(p->t,p->x); /* 1/sqrt(num * denom) */
-    
+
     gf_mul(p->x,p->t,p->z); /* sqrt(num / denom) */
     gf_cond_neg(p->x,gf_lobit(p->x)^low);
     gf_copy(p->z,ONE);
-  
+
     #if EDDSA_USE_SIGMA_ISOGENY
     {
        /* Use 4-isogeny like ed25519:
@@ -1228,7 +1225,7 @@ ristretto_error_t ristretto255_point_decode_like_eddsa_and_mul_by_ratio (
         ristretto_bzero(b,sizeof(b));
         ristretto_bzero(c,sizeof(c));
         ristretto_bzero(d,sizeof(d));
-    } 
+    }
     #elif IMAGINE_TWIST
     {
         gf_mul(p->t,p->x,SQRT_MINUS_ONE);
@@ -1259,10 +1256,10 @@ ristretto_error_t ristretto255_point_decode_like_eddsa_and_mul_by_ratio (
         ristretto_bzero(d,sizeof(d));
     }
     #endif
-    
+
     ristretto_bzero(enc2,sizeof(enc2));
     assert(ristretto255_point_valid(p) || ~succ);
-    
+
     return ristretto_succeed_if(mask_to_bool(succ));
 }
 
@@ -1281,7 +1278,7 @@ static int recode_wnaf (
 ) {
     unsigned int table_size = SCALAR_BITS/(table_bits+1) + 3;
     int position = table_size - 1; /* at the end */
-    
+
     /* place the end marker */
     control[position].power = -1;
     control[position].addend = 0;
@@ -1291,7 +1288,7 @@ static int recode_wnaf (
      * in the actual code that uses it, all for an expected reduction of like 1/5 op.
      * Probably not worth it.
      */
-    
+
     uint64_t current = scalar->limb[0] & 0xFFFF;
     uint32_t mask = (1<<(table_bits+1))-1;
 
@@ -1302,7 +1299,7 @@ static int recode_wnaf (
             /* Refill the 16 high bits of current */
             current += (uint32_t)((scalar->limb[w/B_OVER_16]>>(16*(w%B_OVER_16)))<<16);
         }
-        
+
         while (current & 0xFFFF) {
             assert(position >= 0);
             uint32_t pos = __builtin_ctz((uint32_t)current), odd = (uint32_t)current >> pos;
@@ -1316,7 +1313,7 @@ static int recode_wnaf (
         current >>= 16;
     }
     assert(current==0);
-    
+
     position++;
     unsigned int n = table_size - position;
     unsigned int i;
@@ -1349,7 +1346,7 @@ prepare_wnaf_table(
         add_pniels_to_pt(tmp, twop,0);
         pt_to_pniels(output[i], tmp);
     }
-    
+
     ristretto255_point_destroy(tmp);
     ristretto_bzero(twop,sizeof(twop));
 }
@@ -1377,7 +1374,7 @@ void ristretto255_precompute_wnafs (
         gf_copy(zs[i], tmp[i]->z);
     }
     batch_normalize_niels(out, (const gf *)zs, zis, 1<<RISTRETTO_WNAF_FIXED_TABLE_BITS);
-    
+
     ristretto_bzero(tmp,sizeof(tmp));
     ristretto_bzero(zs,sizeof(zs));
     ristretto_bzero(zis,sizeof(zis));
@@ -1393,13 +1390,13 @@ void ristretto255_base_double_scalarmul_non_secret (
         table_bits_pre = RISTRETTO_WNAF_FIXED_TABLE_BITS;
     struct smvt_control control_var[SCALAR_BITS/((int)(RISTRETTO_WNAF_VAR_TABLE_BITS)+1)+3];
     struct smvt_control control_pre[SCALAR_BITS/((int)(RISTRETTO_WNAF_FIXED_TABLE_BITS)+1)+3];
-    
+
     int ncb_pre = recode_wnaf(control_pre, scalar1, table_bits_pre);
     int ncb_var = recode_wnaf(control_var, scalar2, table_bits_var);
-  
+
     pniels_t precmp_var[1<<(int)(RISTRETTO_WNAF_VAR_TABLE_BITS)];
     prepare_wnaf_table(precmp_var, base2, table_bits_var);
-  
+
     int contp=0, contv=0, i = control_var[0].power;
 
     if (i < 0) {
@@ -1417,7 +1414,7 @@ void ristretto255_base_double_scalarmul_non_secret (
         niels_to_pt(combo, ristretto255_wnaf_base[control_pre[0].addend >> 1]);
         contp++;
     }
-    
+
     for (i--; i >= 0; i--) {
         int cv = (i==control_var[contv].power), cp = (i==control_pre[contp].power);
         point_double_internal(combo,combo,i && !(cv||cp));
@@ -1444,7 +1441,7 @@ void ristretto255_base_double_scalarmul_non_secret (
             contp++;
         }
     }
-    
+
     /* This function is non-secret, but whatever this is cheap. */
     ristretto_bzero(control_var,sizeof(control_var));
     ristretto_bzero(control_pre,sizeof(control_pre));

--- a/src/ristretto_gen_tables.c
+++ b/src/ristretto_gen_tables.c
@@ -7,9 +7,6 @@
  *   Released under the MIT License.  See LICENSE.txt for license information.
  *
  * @brief Ristretto255 global constant table precomputation.
- *
- * @warning This file was automatically generated in Python.
- * Please do not edit it.
  */
 #define _XOPEN_SOURCE 600 /* for posix_memalign */
 #include <stdio.h>

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -7,9 +7,6 @@
  *   Released under the MIT License.  See LICENSE.txt for license information.
  *
  * @brief Ristretto255 high-level functions.
- *
- * @warning This file was automatically generated in Python.
- * Please do not edit it.
  */
 #include "word.h"
 #include "constant_time.h"
@@ -52,7 +49,7 @@ static RISTRETTO_NOINLINE void sc_subx(
         chain >>= WBITS;
     }
     ristretto_word_t borrow = chain+extra; /* = 0 or -1 */
-    
+
     chain = 0;
     for (i=0; i<SCALAR_LIMBS; i++) {
         chain = (chain + out->limb[i]) + (p->limb[i] & borrow);
@@ -69,11 +66,11 @@ static RISTRETTO_NOINLINE void sc_montmul (
     unsigned int i,j;
     ristretto_word_t accum[SCALAR_LIMBS+1] = {0};
     ristretto_word_t hi_carry = 0;
-    
+
     for (i=0; i<SCALAR_LIMBS; i++) {
         ristretto_word_t mand = a->limb[i];
         const ristretto_word_t *mier = b->limb;
-        
+
         ristretto_dword_t chain = 0;
         for (j=0; j<SCALAR_LIMBS; j++) {
             chain += ((ristretto_dword_t)mand)*mier[j] + accum[j];
@@ -81,7 +78,7 @@ static RISTRETTO_NOINLINE void sc_montmul (
             chain >>= WBITS;
         }
         accum[j] = chain;
-        
+
         mand = accum[0] * MONTGOMERY_FACTOR;
         chain = 0;
         mier = sc_p->limb;
@@ -95,7 +92,7 @@ static RISTRETTO_NOINLINE void sc_montmul (
         accum[j-1] = chain;
         hi_carry = chain >> WBITS;
     }
-    
+
     sc_subx(out, accum, sc_p, sc_p, hi_carry);
 }
 
@@ -132,26 +129,26 @@ ristretto_error_t ristretto255_scalar_invert (
     for (i=1; i<=LAST; i++) {
         sc_montmul(precmp[i],precmp[i-1],precmp[LAST]);
     }
-    
+
     /* Sliding window */
     unsigned residue = 0, trailing = 0, started = 0;
     for (i=SCALAR_BITS-1; i>=-SCALAR_WINDOW_BITS; i--) {
-        
+
         if (started) sc_montsqr(out,out);
-        
+
         ristretto_word_t w = (i>=0) ? sc_p->limb[i/WBITS] : 0;
         if (i >= 0 && i<WBITS) {
             assert(w >= 2);
             w-=2;
         }
-        
+
         residue = (residue<<1) | ((w>>(i%WBITS))&1);
         if (residue>>SCALAR_WINDOW_BITS != 0) {
             assert(trailing == 0);
             trailing = residue;
             residue = 0;
         }
-        
+
         if (trailing > 0 && (trailing & ((1<<SCALAR_WINDOW_BITS)-1)) == 0) {
             if (started) {
                 sc_montmul(out,out,precmp[trailing>>(SCALAR_WINDOW_BITS+1)]);
@@ -162,11 +159,11 @@ ristretto_error_t ristretto255_scalar_invert (
             trailing = 0;
         }
         trailing <<= 1;
-        
+
     }
     assert(residue==0);
     assert(trailing==0);
-    
+
     /* Demontgomerize */
     sc_montmul(out,out,ristretto255_scalar_one);
     ristretto_bzero(precmp, sizeof(precmp));
@@ -250,9 +247,9 @@ ristretto_error_t ristretto255_scalar_decode(
         accum = (accum + s->limb[i] - sc_p->limb[i]) >> WBITS;
     }
     /* Here accum == 0 or -1 */
-    
+
     ristretto255_scalar_mul(s,s,ristretto255_scalar_one); /* ham-handed reduce */
-    
+
     return ristretto_succeed_if(~word_is_zero(accum));
 }
 
@@ -271,13 +268,13 @@ void ristretto255_scalar_decode_long(
         ristretto255_scalar_copy(s, ristretto255_scalar_zero);
         return;
     }
-    
+
     size_t i;
     scalar_t t1, t2;
 
     i = ser_len - (ser_len%SCALAR_SER_BYTES);
     if (i==ser_len) i -= SCALAR_SER_BYTES;
-    
+
     scalar_decode_short(t1, &ser[i], ser_len-i);
 
     if (ser_len == sizeof(scalar_t)) {


### PR DESCRIPTION
* Remove '@warning' for generated code: we're no-longer generating
* Set `.travis.yml` to be a C project rather than a Python one
* Rename (aliased) RISTRETTO_FACTOR -> RISTRETTO255_FACTOR
* Remove trailing whitespace