### PR TITLE
Remove gating on COFACTOR, IMAGINE_TWIST, and X_SER_BYTES

### DIFF
--- a/src/f_field.h
+++ b/src/f_field.h
@@ -20,7 +20,6 @@
 
 #define __RISTRETTO_25519_GF_DEFINED__ 1
 #define NLIMBS (40/sizeof(word_t))
-#define X_SER_BYTES 32
 #define SER_BYTES 32
 typedef struct gf_25519_s {
     word_t limb[NLIMBS];

--- a/src/f_generic.c
+++ b/src/f_generic.c
@@ -27,7 +27,7 @@ void gf_serialize (uint8_t serial[SER_BYTES], const gf x, int with_hibit) {
 
     unsigned int j=0, fill=0;
     dword_t buffer = 0;
-    UNROLL for (unsigned int i=0; i<(with_hibit ? X_SER_BYTES : SER_BYTES); i++) {
+    UNROLL for (unsigned int i=0; i<SER_BYTES; i++) {
         if (fill < 8 && j < NLIMBS) {
             buffer |= ((dword_t)red->limb[LIMBPERM(j)]) << fill;
             fill += LIMB_PLACE_VALUE(LIMBPERM(j));
@@ -60,11 +60,10 @@ mask_t gf_deserialize (gf x, const uint8_t serial[SER_BYTES], int with_hibit, ui
     unsigned int j=0, fill=0;
     dword_t buffer = 0;
     dsword_t scarry = 0;
-    const unsigned nbytes = with_hibit ? X_SER_BYTES : SER_BYTES;
     UNROLL for (unsigned int i=0; i<NLIMBS; i++) {
-        UNROLL while (fill < LIMB_PLACE_VALUE(LIMBPERM(i)) && j < nbytes) {
+        UNROLL while (fill < LIMB_PLACE_VALUE(LIMBPERM(i)) && j < SER_BYTES) {
             uint8_t sj = serial[j];
-            if (j==nbytes-1) sj &= ~hi_nmask;
+            if (j==SER_BYTES-1) sj &= ~hi_nmask;
             buffer |= ((dword_t)sj) << fill;
             fill += 8;
             j++;

--- a/src/ristretto_gen_tables.c
+++ b/src/ristretto_gen_tables.c
@@ -34,12 +34,12 @@ void ristretto255_precompute_wnafs (
     const ristretto255_point_t base
 );
 static void field_print(const gf f) {
-    unsigned char ser[X_SER_BYTES];
+    unsigned char ser[SER_BYTES];
     gf_serialize(ser,f,1);
     int b=0, i, comma=0;
     unsigned long long limb = 0;
     printf("{FIELD_LITERAL(");
-    for (i=0; i<X_SER_BYTES; i++) {
+    for (i=0; i<SER_BYTES; i++) {
         limb |= ((uint64_t)ser[i])<<b;
         b += 8;
         if (b >= GF_LIT_LIMB_BITS || i == SER_BYTES-1) {


### PR DESCRIPTION
These were previously used to abstract across different curve types, however for Curve25519 they are always the following:

* `COFACTOR`: 8
* `IMAGINE_TWIST`: 1
* `X_SER_BYTES`: `SER_BYTES` (these are unequal for other curves)

This change removes the special casing for other curves and retains the code relevant to Curve25519.