### PR TITLE
Cleanup header imports (and other misc cleanups)

### DIFF
--- a/src/elligator.c
+++ b/src/elligator.c
@@ -8,18 +8,16 @@
  *
  * @brief Elligator high-level functions.
  */
+
 #include "word.h"
 #include "field.h"
-#include <ristretto255/common.h>
-#include <ristretto255/point.h>
+#include <ristretto255.h>
 
-/* Template stuff */
 #define point_t ristretto255_point_t
 static const int EDWARDS_D = -121665;
 
 extern const gf RISTRETTO255_FACTOR;
 
-/* End of template stuff */
 extern mask_t ristretto255_deisogenize (
     gf_s *__restrict__ s,
     gf_s *__restrict__ inv_el_sum,

--- a/src/ristretto.c
+++ b/src/ristretto.c
@@ -8,30 +8,13 @@
  *
  * @brief Ristretto255 high-level functions.
  */
+
 #define _XOPEN_SOURCE 600 /* for posix_memalign */
 #include "word.h"
 #include "field.h"
 
 #include <ristretto255.h>
 
-/* MSVC has no builtint ctz, this is a fix as in
-https://stackoverflow.com/questions/355967/how-to-use-msvc-intrinsics-to-get-the-equivalent-of-this-gcc-code/5468852#5468852
-*/
-#ifdef _MSC_VER
-#include <intrin.h>
-
-uint32_t __inline ctz(uint32_t value)
-{
-    DWORD trailing_zero = 0;
-    if ( _BitScanForward( &trailing_zero, value ) )
-        return trailing_zero;
-    else
-        return 32;  // This is undefined, I better choose 32 than 0
-}
-#define __builtin_ctz(x) ctz(x)
-#endif
-
-/* Template stuff */
 #define SCALAR_BITS RISTRETTO255_SCALAR_BITS
 #define SCALAR_SER_BYTES RISTRETTO255_SCALAR_BYTES
 #define SCALAR_LIMBS RISTRETTO255_SCALAR_LIMBS
@@ -67,8 +50,6 @@ const gf RISTRETTO255_FACTOR = {FIELD_LITERAL(
 #define EFF_D TWISTED_D
 #define NEG_D 0
 #endif
-
-/* End of template stuff */
 
 extern const gf SQRT_MINUS_ONE;
 
@@ -1036,6 +1017,23 @@ static int recode_wnaf (
     }
     return n-1;
 }
+
+/* MSVC has no builtint ctz, this is a fix as in
+https://stackoverflow.com/questions/355967/how-to-use-msvc-intrinsics-to-get-the-equivalent-of-this-gcc-code/5468852#5468852
+*/
+#ifdef _MSC_VER
+#include <intrin.h>
+
+uint32_t __inline ctz(uint32_t value)
+{
+    DWORD trailing_zero = 0;
+    if ( _BitScanForward( &trailing_zero, value ) )
+        return trailing_zero;
+    else
+        return 32;  // This is undefined, I better choose 32 than 0
+}
+#define __builtin_ctz(x) ctz(x)
+#endif
 
 static void
 prepare_wnaf_table(

--- a/src/ristretto_gen_tables.c
+++ b/src/ristretto_gen_tables.c
@@ -8,14 +8,14 @@
  *
  * @brief Ristretto255 global constant table precomputation.
  */
+
 #define _XOPEN_SOURCE 600 /* for posix_memalign */
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "field.h"
 #include "f_field.h"
-#include "ristretto255/common.h"
-#include "ristretto255/point.h"
+#include <ristretto255.h>
 
 static const unsigned char base_point_ser_for_pregen[SER_BYTES] = {
     0xe2, 0xf2, 0xae, 0x0a, 0x6a, 0xbc, 0x4e, 0x71, 0xa8, 0x84, 0xa9, 0x61, 0xc5, 0x00, 0x51, 0x5f, 0x58, 0xe3, 0x0b, 0x6a, 0xa5, 0x82, 0xdd, 0x8d, 0xb6, 0xa6, 0x59, 0x45, 0xe0, 0x8d, 0x2d, 0x76
@@ -86,8 +86,7 @@ int main(int argc, char **argv) {
 
     printf("/** @warning: this file was automatically generated. */\n");
     printf("#include \"field.h\"\n\n");
-    printf("#include <ristretto255/common.h>\n\n");
-    printf("#include <ristretto255/point.h>\n\n");
+    printf("#include <ristretto255.h>\n\n");
     printf("#define ristretto255__id ristretto255_##_id\n");
 
     output = (const gf_s *)real_point_base;

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -10,10 +10,8 @@
  */
 #include "word.h"
 #include "constant_time.h"
-#include <ristretto255/common.h>
-#include <ristretto255/point.h>
+#include <ristretto255.h>
 
-/* Template stuff */
 #define SCALAR_BITS RISTRETTO255_SCALAR_BITS
 #define SCALAR_SER_BYTES RISTRETTO255_SCALAR_BYTES
 #define SCALAR_LIMBS RISTRETTO255_SCALAR_LIMBS
@@ -25,7 +23,6 @@ static const scalar_t sc_p = {{{
 }}}, sc_r2 = {{{
     SC_LIMB(0xa40611e3449c0f01), SC_LIMB(0xd00e1ba768859347), SC_LIMB(0xceec73d217f5be65), SC_LIMB(0x0399411b7c309a3d)
 }}};
-/* End of template stuff */
 
 #define WBITS RISTRETTO_WORD_BITS /* NB this may be different from ARCH_WORD_BITS */
 


### PR DESCRIPTION
* `#include <ristretto255.h>` in lieu of separate `common.h` and `point.h`
* Remove "template stuff" comments
* Bury MSVC workaround for `__builtin_ctz` near where it's used