### PR TITLE
Add "Ristretto Developers" to all Copyright declarations

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,15 @@
+# libristretto255 contributors
+
+This project is a fork of [libdecaf] by Mike Hamburg. libdecaf is
+Copyright (c) 2014-2017 Cryptography Research, Inc (a division of Rambus)
+and released under the [MIT license](https://sourceforge.net/p/ed448goldilocks/code/ci/master/tree/LICENSE.txt).
+
+[libdecaf]: https://sourceforge.net/projects/ed448goldilocks/
+
+The following additional people (credited as "Ristretto Developers") have
+contributed to this library and have also granted the right to use their
+contributions under the terms of the [MIT license]:
+
+[MIT license]: https://github.com/Ristretto/libristretto255/blob/master/LICENSE.txt
+
+* [Tony Arcieri (@tarcieri)](https://github.com/tarcieri)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2017 Cryptography Research, Inc.
+Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2018 Cryptography Research, Inc.
+# Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.
 # Released under the MIT License.  See LICENSE.txt for license information.
 
 UNAME := $(shell uname)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Check back later for updates.
 
 ## License
 
-Copyright (c) 2014-2018 Cryptography Research, Inc (a division of Rambus).
+Copyright (c) 2014-2018 Ristretto Developers ([AUTHORS.md]),
+Cryptography Research, Inc (a division of Rambus).
 
 Distributed under the MIT License. See [LICENSE.txt] for more information.
 
+[AUTHORS.md]:  https://github.com/Ristretto/libristretto255/blob/master/AUTHORS.md
 [LICENSE.txt]: https://github.com/Ristretto/libristretto255/blob/master/LICENSE.txt

--- a/include/ristretto255/common.h
+++ b/include/ristretto255/common.h
@@ -3,7 +3,7 @@
  * @author Mike Hamburg
  *
  * @copyright
- *   Copyright (c) 2015 Cryptography Research, Inc.  \n
+ *   Copyright (c) 2015-2018 Ristretto Developers, Cryptography Research, Inc.  \n
  *   Released under the MIT License.  See LICENSE.txt for license information.
  *
  * @brief Common utility headers for the Ristretto255 library.

--- a/src/arch/32/arch_intrinsics.h
+++ b/src/arch/32/arch_intrinsics.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Cryptography Research, Inc.
+/* Copyright (c) 2016-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 

--- a/src/arch/32/f_impl.c
+++ b/src/arch/32/f_impl.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Cryptography Research, Inc.
+/* Copyright (c) 2016-2018 Ristretto Developers,  Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 
@@ -6,11 +6,11 @@
 
 void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
     const uint32_t *a = as->limb, *b = bs->limb, maske = ((1<<26)-1), masko = ((1<<25)-1);
-    
+
     uint32_t bh[9];
     int i,j;
     for (i=0; i<9; i++) bh[i] = b[i+1] * 19;
-    
+
     uint32_t *c = cs->limb;
 
     uint64_t accum = 0;
@@ -41,12 +41,12 @@ void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
         accum >>= 25;
         i++;
     }
-    
+
     accum *= 19;
     accum += c[0];
     c[0] = accum & maske;
     accum >>= 26;
-    
+
     assert(accum < masko);
     c[1] += accum;
 }
@@ -73,12 +73,12 @@ void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
         accum >>= 25;
         i++;
     }
-    
+
     accum *= 19;
     accum += c[0];
     c[0] = accum & maske;
     accum >>= 26;
-    
+
     assert(accum < masko);
     c[1] += accum;
 }

--- a/src/arch/32/f_impl.h
+++ b/src/arch/32/f_impl.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2016 Cryptography Research, Inc.
+/* Copyright (c) 2014-2018 Ristretto Developers,  Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 

--- a/src/arch/arm32/arch_intrinsics.h
+++ b/src/arch/arm32/arch_intrinsics.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Cryptography Research, Inc.
+/* Copyright (c) 2016-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 
@@ -17,7 +17,7 @@ uint32_t word_is_zero(uint32_t a) {
 static __inline__ __attribute((always_inline,unused))
 uint64_t widemul(uint32_t a, uint32_t b) {
     /* Could be UMULL, but it's hard to express to CC that the registers must be different */
-    return ((uint64_t)a) * b; 
+    return ((uint64_t)a) * b;
 }
 
 #endif /* __ARCH_ARM_32_ARCH_INTRINSICS_H__ */

--- a/src/arch/neon/arch_intrinsics.h
+++ b/src/arch/neon/arch_intrinsics.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Cryptography Research, Inc.
+/* Copyright (c) 2016-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 
@@ -17,7 +17,7 @@ uint32_t word_is_zero(uint32_t a) {
 static __inline__ __attribute((always_inline,unused))
 uint64_t widemul(uint32_t a, uint32_t b) {
     /* Could be UMULL, but it's hard to express to CC that the registers must be different */
-    return ((uint64_t)a) * b; 
+    return ((uint64_t)a) * b;
 }
 
 #endif /* __ARCH_NEON_ARCH_INTRINSICS_H__ */

--- a/src/arch/ref64/arch_intrinsics.h
+++ b/src/arch/ref64/arch_intrinsics.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Cryptography Research, Inc.
+/* Copyright (c) 2016-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 
@@ -15,7 +15,7 @@ uint64_t word_is_zero(uint64_t a) {
 
 static __inline__ __attribute((always_inline,unused))
 __uint128_t widemul(uint64_t a, uint64_t b) {
-    return ((__uint128_t)a) * b; 
+    return ((__uint128_t)a) * b;
 }
 
 #endif /* ARCH_REF64_ARCH_INTRINSICS_H__ */

--- a/src/arch/ref64/f_impl.c
+++ b/src/arch/ref64/f_impl.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014 Cryptography Research, Inc.
+/* Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 
@@ -6,11 +6,11 @@
 
 void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
     const uint64_t *a = as->limb, *b = bs->limb, mask = ((1ull<<51)-1);
-    
+
     uint64_t bh[4];
     int i,j;
     for (i=0; i<4; i++) bh[i] = b[i+1] * 19;
-    
+
     uint64_t *c = cs->limb;
 
     __uint128_t accum = 0;
@@ -24,12 +24,12 @@ void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
         c[i] = accum & mask;
         accum >>= 51;
     }
-    
+
     accum *= 19;
     accum += c[0];
     c[0] = accum & mask;
     accum >>= 51;
-    
+
     assert(accum < mask);
     c[1] += accum;
 }
@@ -37,7 +37,7 @@ void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
 void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
     const uint64_t *a = as->limb, mask = ((1ull<<51)-1);
     int i;
-    
+
     uint64_t *c = cs->limb;
 
     __uint128_t accum = 0;
@@ -46,12 +46,12 @@ void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
         c[i] = accum & mask;
         accum >>= 51;
     }
-    
+
     accum *= 19;
     accum += c[0];
     c[0] = accum & mask;
     accum >>= 51;
-    
+
     assert(accum < mask);
     c[1] += accum;
 }

--- a/src/arch/ref64/f_impl.h
+++ b/src/arch/ref64/f_impl.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2016 Cryptography Research, Inc.
+/* Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 

--- a/src/arch/x86_64/arch_intrinsics.h
+++ b/src/arch/x86_64/arch_intrinsics.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2016 Cryptography Research, Inc.
+/* Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 
@@ -89,7 +89,7 @@ static __inline__ __uint128_t widemul2(const uint64_t *a, const uint64_t *b) {
 
 static __inline__ void mac(__uint128_t *acc, const uint64_t *a, const uint64_t *b) {
   uint64_t lo = *acc, hi = *acc>>64;
-  
+
   #ifdef __BMI2__
       uint64_t c,d;
       __asm__ volatile
@@ -110,14 +110,14 @@ static __inline__ void mac(__uint128_t *acc, const uint64_t *a, const uint64_t *
            : [b]"m"(*b), [a]"m"(*a)
            : "rax", "rdx", "cc");
   #endif
-  
+
   *acc = (((__uint128_t)(hi))<<64) | lo;
 }
 
 static __inline__ void macac(__uint128_t *acc, __uint128_t *acc2, const uint64_t *a, const uint64_t *b) {
   uint64_t lo = *acc, hi = *acc>>64;
   uint64_t lo2 = *acc2, hi2 = *acc2>>64;
-  
+
   #ifdef __BMI2__
       uint64_t c,d;
       __asm__ volatile
@@ -142,14 +142,14 @@ static __inline__ void macac(__uint128_t *acc, __uint128_t *acc2, const uint64_t
            : [b]"m"(*b), [a]"m"(*a)
            : "rax", "rdx", "cc");
   #endif
-  
+
   *acc = (((__uint128_t)(hi))<<64) | lo;
   *acc2 = (((__uint128_t)(hi2))<<64) | lo2;
 }
 
 static __inline__ void mac_rm(__uint128_t *acc, uint64_t a, const uint64_t *b) {
   uint64_t lo = *acc, hi = *acc>>64;
-  
+
   #ifdef __BMI2__
       uint64_t c,d;
       __asm__ volatile
@@ -169,13 +169,13 @@ static __inline__ void mac_rm(__uint128_t *acc, uint64_t a, const uint64_t *b) {
            : [b]"m"(*b), [a]"r"(a)
            : "rax", "rdx", "cc");
   #endif
-  
+
   *acc = (((__uint128_t)(hi))<<64) | lo;
 }
 
 static __inline__ void mac_rr(__uint128_t *acc, uint64_t a, const uint64_t b) {
   uint64_t lo = *acc, hi = *acc>>64;
-  
+
   #ifdef __BMI2__
       uint64_t c,d;
       __asm__ volatile
@@ -194,13 +194,13 @@ static __inline__ void mac_rr(__uint128_t *acc, uint64_t a, const uint64_t b) {
            : [b]"r"(b)
            : "rdx", "cc");
   #endif
-  
+
   *acc = (((__uint128_t)(hi))<<64) | lo;
 }
 
 static __inline__ void mac2(__uint128_t *acc, const uint64_t *a, const uint64_t *b) {
   uint64_t lo = *acc, hi = *acc>>64;
-  
+
   #ifdef __BMI2__
       uint64_t c,d;
       __asm__ volatile
@@ -223,7 +223,7 @@ static __inline__ void mac2(__uint128_t *acc, const uint64_t *a, const uint64_t 
            : [b]"m"(*b), [a]"m"(*a)
            : "rax", "rdx", "cc");
   #endif
-  
+
   *acc = (((__uint128_t)(hi))<<64) | lo;
 }
 
@@ -277,7 +277,7 @@ static __inline__ void msb2(__uint128_t *acc, const uint64_t *a, const uint64_t 
            : "rax", "rdx", "cc");
   #endif
   *acc = (((__uint128_t)(hi))<<64) | lo;
-  
+
 }
 
 static __inline__ void mrs(__uint128_t *acc, const uint64_t *a, const uint64_t *b) {

--- a/src/arch/x86_64/f_impl.c
+++ b/src/arch/x86_64/f_impl.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014 Cryptography Research, Inc.
+/* Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 
@@ -8,70 +8,70 @@
 void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
     const uint64_t *a = as->limb, *b = bs->limb, mask = ((1ull<<51)-1);
     uint64_t *c = cs->limb;
-    
+
     __uint128_t accum0, accum1, accum2;
-    
+
     uint64_t ai = a[0];
     accum0 = widemul_rm(ai, &b[0]);
     accum1 = widemul_rm(ai, &b[1]);
     accum2 = widemul_rm(ai, &b[2]);
-    
+
     ai = a[1];
     mac_rm(&accum2, ai, &b[1]);
     mac_rm(&accum1, ai, &b[0]);
     ai *= 19;
     mac_rm(&accum0, ai, &b[4]);
-    
+
     ai = a[2];
     mac_rm(&accum2, ai, &b[0]);
     ai *= 19;
     mac_rm(&accum0, ai, &b[3]);
     mac_rm(&accum1, ai, &b[4]);
-    
+
     ai = a[3] * 19;
     mac_rm(&accum0, ai, &b[2]);
     mac_rm(&accum1, ai, &b[3]);
     mac_rm(&accum2, ai, &b[4]);
-    
+
     ai = a[4] * 19;
     mac_rm(&accum0, ai, &b[1]);
     mac_rm(&accum1, ai, &b[2]);
     mac_rm(&accum2, ai, &b[3]);
-    
+
     uint64_t c0 = accum0 & mask;
     accum1 += shrld(accum0, 51);
     uint64_t c1 = accum1 & mask;
     accum2 += shrld(accum1, 51);
     c[2] = accum2 & mask;
-    
+
     accum0 = shrld(accum2, 51);
 
     mac_rm(&accum0, ai, &b[4]);
-    
+
     ai = a[0];
     mac_rm(&accum0, ai, &b[3]);
     accum1 = widemul_rm(ai, &b[4]);
-    
+
     ai = a[1];
     mac_rm(&accum0, ai, &b[2]);
     mac_rm(&accum1, ai, &b[3]);
-    
+
     ai = a[2];
     mac_rm(&accum0, ai, &b[1]);
     mac_rm(&accum1, ai, &b[2]);
-    
+
     ai = a[3];
     mac_rm(&accum0, ai, &b[0]);
     mac_rm(&accum1, ai, &b[1]);
-    
+
     ai = a[4];
     mac_rm(&accum1, ai, &b[0]);
     /* Here accum1 < 5*(9*2^51)^2 */
-    
+
     c[3] = accum0 & mask;
     accum1 += shrld(accum0, 51);
     c[4] = accum1 & mask;
-    
+
     uint64_t a1 = shrld(accum1,51);
     /* Here a1 < (5*(9*2^51)^2 + small) >> 51 = 405 * 2^51 + small
      * a1 * 19 + c0 < (405*19+1)*2^51 + small < 2^13 * 2^51.
@@ -84,56 +84,56 @@ void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
 void gf_sqr (gf_s *__restrict__ cs, const gf as) {
     const uint64_t *a = as->limb, mask = ((1ull<<51)-1);
     uint64_t *c = cs->limb;
-    
+
     __uint128_t accum0, accum1, accum2;
-    
+
     uint64_t ai = a[0];
     accum0 = widemul_rr(ai, ai);
     ai *= 2;
     accum1 = widemul_rm(ai, &a[1]);
     accum2 = widemul_rm(ai, &a[2]);
-    
+
     ai = a[1];
     mac_rr(&accum2, ai, ai);
     ai *= 38;
     mac_rm(&accum0, ai, &a[4]);
-    
+
     ai = a[2] * 38;
     mac_rm(&accum0, ai, &a[3]);
     mac_rm(&accum1, ai, &a[4]);
-    
+
     ai = a[3] * 19;
     mac_rm(&accum1, ai, &a[3]);
     ai *= 2;
     mac_rm(&accum2, ai, &a[4]);
-    
+
     uint64_t c0 = accum0 & mask;
     accum1 += shrld(accum0, 51);
     uint64_t c1 = accum1 & mask;
     accum2 += shrld(accum1, 51);
     c[2] = accum2 & mask;
-    
+
     accum0 = accum2 >> 51;
-    
+
     ai = a[0]*2;
     mac_rm(&accum0, ai, &a[3]);
     accum1 = widemul_rm(ai, &a[4]);
-    
+
     ai = a[1]*2;
     mac_rm(&accum0, ai, &a[2]);
     mac_rm(&accum1, ai, &a[3]);
-    
+
     mac_rr(&accum0, a[4]*19, a[4]);
     mac_rr(&accum1, a[2], a[2]);
-    
+
     c[3] = accum0 & mask;
     accum1 += shrld(accum0, 51);
     c[4] = accum1 & mask;
-    
+
     /* 2^102 * 16 * 5 * 19 * (1+ep) >> 64
      * = 2^(-13 + <13)
      */
-    
+
     uint64_t a1 = shrld(accum1,51);
     accum1 = a1 * 19 + c0;
     c[0] = accum1 & mask;
@@ -147,25 +147,25 @@ void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
     __uint128_t accum = widemul_rm(b, &a[0]);
     uint64_t c0 = accum & mask;
     accum = shrld(accum,51);
-    
+
     mac_rm(&accum, b, &a[1]);
     uint64_t c1 = accum & mask;
     accum = shrld(accum,51);
-    
+
     mac_rm(&accum, b, &a[2]);
     c[2] = accum & mask;
     accum = shrld(accum,51);
-    
+
     mac_rm(&accum, b, &a[3]);
     c[3] = accum & mask;
     accum = shrld(accum,51);
-    
+
     mac_rm(&accum, b, &a[4]);
     c[4] = accum & mask;
 
     uint64_t a1 = shrld(accum,51);
     a1 = a1*19+c0;
-    
+
     c[0] = a1 & mask;
     c[1] = c1 + (a1>>51);
 }

--- a/src/arch/x86_64/f_impl.h
+++ b/src/arch/x86_64/f_impl.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014-2016 Cryptography Research, Inc.
+/* Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 

--- a/src/constant_time.h
+++ b/src/constant_time.h
@@ -1,7 +1,7 @@
 /**
  * @file constant_time.h
  * @copyright
- *   Copyright (c) 2014 Cryptography Research, Inc.  \n
+ *   Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.  \n
  *   Released under the MIT License.  See LICENSE.txt for license information.
  * @author Mike Hamburg
  *
@@ -68,7 +68,7 @@ constant_time_cond_swap (
     word_t k;
     unsigned char *a = (unsigned char *)a_;
     unsigned char *b = (unsigned char *)b_;
-    
+
     big_register_t br_mask = br_set_to_mask(doswap);
     for (k=0; k<=elem_bytes-sizeof(big_register_t); k+=sizeof(big_register_t)) {
         if (elem_bytes % sizeof(big_register_t)) {
@@ -111,7 +111,7 @@ constant_time_cond_swap (
             }
         }
     }
-    
+
     if (elem_bytes % sizeof(word_t)) {
         for (; k<elem_bytes; k+=1) {
             unsigned char xor = a[k] ^ b[k];
@@ -140,14 +140,14 @@ constant_time_lookup (
     word_t idx
 ) {
     big_register_t big_one = br_set_to_mask(1), big_i = br_set_to_mask(idx);
-    
+
     /* Can't do pointer arithmetic on void* */
     unsigned char *out = (unsigned char *)out_;
     const unsigned char *table = (const unsigned char *)table_;
     word_t j,k;
-    
+
     memset(out, 0, elem_bytes);
-    for (j=0; j<n_table; j++, big_i-=big_one) {        
+    for (j=0; j<n_table; j++, big_i-=big_one) {
         big_register_t br_mask = br_is_zero(big_i);
         for (k=0; k<=elem_bytes-sizeof(big_register_t); k+=sizeof(big_register_t)) {
             if (elem_bytes % sizeof(big_register_t)) {
@@ -172,7 +172,7 @@ constant_time_lookup (
                 }
             }
         }
-        
+
         if (elem_bytes % sizeof(word_t)) {
             for (; k<elem_bytes; k+=1) {
                 out[k] |= mask & table[k+j*elem_bytes];
@@ -199,13 +199,13 @@ constant_time_insert (
     word_t idx
 ) {
     big_register_t big_one = br_set_to_mask(1), big_i = br_set_to_mask(idx);
-    
+
     /* Can't do pointer arithmetic on void* */
     const unsigned char *in = (const unsigned char *)in_;
     unsigned char *table = (unsigned char *)table_;
     word_t j,k;
-    
-    for (j=0; j<n_table; j++, big_i-=big_one) {        
+
+    for (j=0; j<n_table; j++, big_i-=big_one) {
         big_register_t br_mask = br_is_zero(big_i);
         for (k=0; k<=elem_bytes-sizeof(big_register_t); k+=sizeof(big_register_t)) {
             if (elem_bytes % sizeof(big_register_t)) {
@@ -237,7 +237,7 @@ constant_time_insert (
                 }
             }
         }
-        
+
         if (elem_bytes % sizeof(word_t)) {
             for (; k<elem_bytes; k+=1) {
                 table[k+j*elem_bytes]
@@ -263,7 +263,7 @@ constant_time_mask (
 ) {
     unsigned char *a = (unsigned char *)a_;
     const unsigned char *b = (const unsigned char *)b_;
-    
+
     word_t k;
     big_register_t br_mask = br_set_to_mask(mask);
     for (k=0; k<=elem_bytes-sizeof(big_register_t); k+=sizeof(big_register_t)) {
@@ -287,7 +287,7 @@ constant_time_mask (
             }
         }
     }
-    
+
     if (elem_bytes % sizeof(word_t)) {
         for (; k<elem_bytes; k+=1) {
             a[k] = mask & b[k];
@@ -317,7 +317,7 @@ constant_time_select (
     unsigned char *a = (unsigned char *)a_;
     const unsigned char *bTrue = (const unsigned char *)bTrue_;
     const unsigned char *bFalse = (const unsigned char *)bFalse_;
-    
+
     alignment_bytes |= elem_bytes;
 
     word_t k;
@@ -351,7 +351,7 @@ constant_time_select (
             }
         }
     }
-    
+
     if (elem_bytes % sizeof(word_t)) {
         for (; k<elem_bytes; k+=1) {
             a[k] = ( mask & bTrue[k]) | (~mask & bFalse[k]);

--- a/src/f_arithmetic.c
+++ b/src/f_arithmetic.c
@@ -2,7 +2,7 @@
  * @cond internal
  * @file f_arithmetic.c
  * @copyright
- *   Copyright (c) 2014 Cryptography Research, Inc.  \n
+ *   Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.  \n
  *   Released under the MIT License.  See LICENSE.txt for license information.
  * @author Mike Hamburg
  * @brief Field-specific arithmetic.
@@ -14,7 +14,7 @@
 /* Guarantee: a^2 x = 0 if x = 0; else a^2 x = 1 or SQRT_MINUS_ONE; */
 mask_t gf_isr (gf a, const gf x) {
     gf L0, L1, L2, L3;
-    
+
     gf_sqr (L0, x);
     gf_mul (L1, L0, x);
     gf_sqr (L0, L1);
@@ -30,7 +30,7 @@ mask_t gf_isr (gf a, const gf x) {
     gf_sqrn(L2, L0, 25);
     gf_mul (L3, L2, L0);
     gf_sqrn(L2, L3, 25);
-    gf_mul (L1, L2, L0);    
+    gf_mul (L1, L2, L0);
     gf_sqrn(L2, L1, 50);
     gf_mul (L0, L2, L3);
     gf_sqrn(L2, L0, 125);
@@ -44,7 +44,7 @@ mask_t gf_isr (gf a, const gf x) {
     mask_t one = gf_eq(L3,ONE);
     mask_t succ = one | gf_eq(L1,ZERO);
     mask_t qr   = one | gf_eq(L3,SQRT_MINUS_ONE);
-    
+
     constant_time_select(L2, SQRT_MINUS_ONE, ONE, sizeof(L2), qr, 0);
     gf_mul (a,L2,L0);
     return succ;

--- a/src/field.h
+++ b/src/field.h
@@ -2,7 +2,7 @@
  * @file field.h
  * @brief Generic gf header.
  * @copyright
- *   Copyright (c) 2014 Cryptography Research, Inc.  \n
+ *   Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.  \n
  *   Released under the MIT License.  See LICENSE.txt for license information.
  * @author Mike Hamburg
  */

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 Cryptography Research, Inc.
+/* Copyright (c) 2015-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 

--- a/src/word.h
+++ b/src/word.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2014 Cryptography Research, Inc.
+/* Copyright (c) 2014-2018 Ristretto Developers, Cryptography Research, Inc.
  * Released under the MIT License.  See LICENSE.txt for license information.
  */
 
@@ -63,7 +63,7 @@ extern int posix_memalign(void **, size_t, size_t);
 #else
     #error "libristretto255 only supports 32-bit and 64-bit architectures."
 #endif
-    
+
 /* Scalar limbs are keyed off of the API word size instead of the arch word size. */
 #if RISTRETTO_WORD_BITS == 64
     #define SC_LIMB(x) (x##ull)
@@ -130,7 +130,7 @@ extern int posix_memalign(void **, size_t, size_t);
     typedef uint32x4_t big_register_t;
     typedef uint64x2_t uint64xn_t;
     typedef uint32x4_t uint32xn_t;
-    
+
     static RISTRETTO_INLINE big_register_t
     br_set_to_mask(mask_t x) {
         return vdupq_n_u32(x);
@@ -230,9 +230,9 @@ typedef struct {
 static RISTRETTO_INLINE void *
 malloc_vector(size_t size) {
     void *out = NULL;
-    
+
     int ret = posix_memalign(&out, sizeof(big_register_t), size);
-    
+
     if (ret) {
         return NULL;
     } else {


### PR DESCRIPTION
The explicit list is given in the newly added `AUTHORS.md`.

The intent here is to make it clear that libristretto255 is not a CRI product, but instead an OSS project developed from MIT-licensed CRI code.