### PR TITLE
Replace all boxed '*_t[1]' typedefs with plain structs

### DIFF
--- a/include/ristretto255.h
+++ b/include/ristretto255.h
@@ -120,9 +120,9 @@ void ristretto_bzero (
 /** @brief Galois field element internal structure */
 #define RISTRETTO255_FIELD_LIMBS (40/sizeof(ristretto_word_t))
 
-typedef struct gf_25519_s {
+typedef struct {
     ristretto_word_t limb[RISTRETTO255_FIELD_LIMBS];
-} __attribute__((aligned(32))) gf_25519_s, gf_25519_t[1];
+} __attribute__((aligned(32))) gf_25519_t;
 /** @endcond */
 
 /** Number of bytes in a serialized point. */
@@ -143,11 +143,11 @@ typedef struct gf_25519_s {
 #define RISTRETTO255_REMOVED_COFACTOR 8
 
 /** Representation of a point on the elliptic curve. */
-typedef struct ristretto255_point_s {
+typedef struct {
     /** @cond internal */
     gf_25519_t x,y,z,t; /* Twisted extended homogeneous coordinates */
     /** @endcond */
-} ristretto255_point_t[1];
+} ristretto255_point_t;
 
 /** Precomputed table based on a point.  Can be trivial implementation. */
 struct ristretto255_precomputed_s;
@@ -159,11 +159,11 @@ typedef struct ristretto255_precomputed_s ristretto255_precomputed_s;
 extern const size_t ristretto255_sizeof_precomputed_s, ristretto255_alignof_precomputed_s;
 
 /** Representation of an element of the scalar field. */
-typedef struct ristretto255_scalar_s {
+typedef struct {
     /** @cond internal */
     ristretto_word_t limb[RISTRETTO255_SCALAR_LIMBS];
     /** @endcond */
-} ristretto255_scalar_t[1];
+} ristretto255_scalar_t;
 
 #if defined _MSC_VER
 
@@ -198,7 +198,7 @@ extern const ristretto255_point_t ristretto255_point_identity;
 extern const ristretto255_point_t ristretto255_point_base;
 
 /** Precomputed table of multiples of the base point on the curve. */
-extern const struct ristretto255_precomputed_s *ristretto255_precomputed_base;
+extern const ristretto255_precomputed_s *ristretto255_precomputed_base;
 
 #endif // _MSC_VER
 /**
@@ -212,7 +212,7 @@ extern const struct ristretto255_precomputed_s *ristretto255_precomputed_base;
  * and has been reduced modulo that modulus.
  */
 ristretto_error_t ristretto255_scalar_decode (
-    ristretto255_scalar_t out,
+    ristretto255_scalar_t *out,
     const unsigned char ser[RISTRETTO255_SCALAR_BYTES]
 ) RISTRETTO_WARN_UNUSED RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
@@ -225,7 +225,7 @@ ristretto_error_t ristretto255_scalar_decode (
  * @param [out] out Deserialized form.
  */
 void ristretto255_scalar_decode_long (
-    ristretto255_scalar_t out,
+    ristretto255_scalar_t *out,
     const unsigned char *ser,
     size_t ser_len
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
@@ -238,7 +238,7 @@ void ristretto255_scalar_decode_long (
  */
 void ristretto255_scalar_encode (
     unsigned char ser[RISTRETTO255_SCALAR_BYTES],
-    const ristretto255_scalar_t s
+    const ristretto255_scalar_t *s
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE RISTRETTO_NOINLINE;
 
 /**
@@ -248,9 +248,9 @@ void ristretto255_scalar_encode (
  * @param [out] out a+b.
  */
 void ristretto255_scalar_add (
-    ristretto255_scalar_t out,
-    const ristretto255_scalar_t a,
-    const ristretto255_scalar_t b
+    ristretto255_scalar_t *out,
+    const ristretto255_scalar_t *a,
+    const ristretto255_scalar_t *b
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -261,8 +261,8 @@ void ristretto255_scalar_add (
  * @retval RISTRETTO_FALSE The scalars are not equal.
  */
 ristretto_bool_t ristretto255_scalar_eq (
-    const ristretto255_scalar_t a,
-    const ristretto255_scalar_t b
+    const ristretto255_scalar_t *a,
+    const ristretto255_scalar_t *b
 ) RISTRETTO_WARN_UNUSED RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -272,9 +272,9 @@ ristretto_bool_t ristretto255_scalar_eq (
  * @param [out] out a-b.
  */
 void ristretto255_scalar_sub (
-    ristretto255_scalar_t out,
-    const ristretto255_scalar_t a,
-    const ristretto255_scalar_t b
+    ristretto255_scalar_t *out,
+    const ristretto255_scalar_t *a,
+    const ristretto255_scalar_t *b
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -284,9 +284,9 @@ void ristretto255_scalar_sub (
  * @param [out] out a*b.
  */
 void ristretto255_scalar_mul (
-    ristretto255_scalar_t out,
-    const ristretto255_scalar_t a,
-    const ristretto255_scalar_t b
+    ristretto255_scalar_t *out,
+    const ristretto255_scalar_t *a,
+    const ristretto255_scalar_t *b
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -295,8 +295,8 @@ void ristretto255_scalar_mul (
 * @param [out] out a/2.
 */
 void ristretto255_scalar_halve (
-   ristretto255_scalar_t out,
-   const ristretto255_scalar_t a
+   ristretto255_scalar_t *out,
+   const ristretto255_scalar_t *a
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -306,8 +306,8 @@ void ristretto255_scalar_halve (
  * @return RISTRETTO_SUCCESS The input is nonzero.
  */
 ristretto_error_t ristretto255_scalar_invert (
-    ristretto255_scalar_t out,
-    const ristretto255_scalar_t a
+    ristretto255_scalar_t *out,
+    const ristretto255_scalar_t *a
 ) RISTRETTO_WARN_UNUSED RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -317,8 +317,8 @@ ristretto_error_t ristretto255_scalar_invert (
  * @param [out] out Will become a copy of a.
  */
 static inline void RISTRETTO_NONNULL ristretto255_scalar_copy (
-    ristretto255_scalar_t out,
-    const ristretto255_scalar_t a
+    ristretto255_scalar_t *out,
+    const ristretto255_scalar_t *a
 ) {
     *out = *a;
 }
@@ -329,7 +329,7 @@ static inline void RISTRETTO_NONNULL ristretto255_scalar_copy (
  * @param [out] out Will become equal to a.
  */
 void ristretto255_scalar_set_unsigned (
-    ristretto255_scalar_t out,
+    ristretto255_scalar_t *out,
     uint64_t a
 ) RISTRETTO_NONNULL;
 
@@ -341,7 +341,7 @@ void ristretto255_scalar_set_unsigned (
  */
 void ristretto255_point_encode (
     uint8_t ser[RISTRETTO255_SER_BYTES],
-    const ristretto255_point_t pt
+    const ristretto255_point_t *pt
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -359,7 +359,7 @@ void ristretto255_point_encode (
  * ser does not represent a point.
  */
 ristretto_error_t ristretto255_point_decode (
-    ristretto255_point_t pt,
+    ristretto255_point_t *pt,
     const uint8_t ser[RISTRETTO255_SER_BYTES],
     ristretto_bool_t allow_identity
 ) RISTRETTO_WARN_UNUSED RISTRETTO_NONNULL RISTRETTO_NOINLINE;
@@ -372,8 +372,8 @@ ristretto_error_t ristretto255_point_decode (
  * @param [in] b Any point.
  */
 static inline void RISTRETTO_NONNULL ristretto255_point_copy (
-    ristretto255_point_t a,
-    const ristretto255_point_t b
+    ristretto255_point_t *a,
+    const ristretto255_point_t *b
 ) {
     *a=*b;
 }
@@ -388,8 +388,8 @@ static inline void RISTRETTO_NONNULL ristretto255_point_copy (
  * @retval RISTRETTO_FALSE The points are not equal.
  */
 ristretto_bool_t ristretto255_point_eq (
-    const ristretto255_point_t a,
-    const ristretto255_point_t b
+    const ristretto255_point_t *a,
+    const ristretto255_point_t *b
 ) RISTRETTO_WARN_UNUSED RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -402,9 +402,9 @@ ristretto_bool_t ristretto255_point_eq (
  * @param [in] b An addend.
  */
 void ristretto255_point_add (
-    ristretto255_point_t sum,
-    const ristretto255_point_t a,
-    const ristretto255_point_t b
+    ristretto255_point_t *sum,
+    const ristretto255_point_t *a,
+    const ristretto255_point_t *b
 ) RISTRETTO_NONNULL;
 
 /**
@@ -415,8 +415,8 @@ void ristretto255_point_add (
  * @param [in] a A point.
  */
 void ristretto255_point_double (
-    ristretto255_point_t two_a,
-    const ristretto255_point_t a
+    ristretto255_point_t *two_a,
+    const ristretto255_point_t *a
 ) RISTRETTO_NONNULL;
 
 /**
@@ -429,9 +429,9 @@ void ristretto255_point_double (
  * @param [in] b The subtrahend.
  */
 void ristretto255_point_sub (
-    ristretto255_point_t diff,
-    const ristretto255_point_t a,
-    const ristretto255_point_t b
+    ristretto255_point_t *diff,
+    const ristretto255_point_t *a,
+    const ristretto255_point_t *b
 ) RISTRETTO_NONNULL;
 
 /**
@@ -442,8 +442,8 @@ void ristretto255_point_sub (
  * @param [in] a The input point.
  */
 void ristretto255_point_negate (
-   ristretto255_point_t nega,
-   const ristretto255_point_t a
+   ristretto255_point_t *nega,
+   const ristretto255_point_t *a
 ) RISTRETTO_NONNULL;
 
 /**
@@ -454,9 +454,9 @@ void ristretto255_point_negate (
  * @param [in] scalar The scalar to multiply by.
  */
 void ristretto255_point_scalarmul (
-    ristretto255_point_t scaled,
-    const ristretto255_point_t base,
-    const ristretto255_scalar_t scalar
+    ristretto255_point_t *scaled,
+    const ristretto255_point_t *base,
+    const ristretto255_scalar_t *scalar
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -479,7 +479,7 @@ void ristretto255_point_scalarmul (
 ristretto_error_t ristretto255_direct_scalarmul (
     uint8_t scaled[RISTRETTO255_SER_BYTES],
     const uint8_t base[RISTRETTO255_SER_BYTES],
-    const ristretto255_scalar_t scalar,
+    const ristretto255_scalar_t *scalar,
     ristretto_bool_t allow_identity,
     ristretto_bool_t short_circuit
 ) RISTRETTO_NONNULL RISTRETTO_WARN_UNUSED RISTRETTO_NOINLINE;
@@ -495,7 +495,7 @@ ristretto_error_t ristretto255_direct_scalarmul (
  */
 void ristretto255_precompute (
     ristretto255_precomputed_s *a,
-    const ristretto255_point_t b
+    const ristretto255_point_t *b
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -510,9 +510,9 @@ void ristretto255_precompute (
  * @param [in] scalar The scalar to multiply by.
  */
 void ristretto255_precomputed_scalarmul (
-    ristretto255_point_t scaled,
+    ristretto255_point_t *scaled,
     const ristretto255_precomputed_s *base,
-    const ristretto255_scalar_t scalar
+    const ristretto255_scalar_t *scalar
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -529,11 +529,11 @@ void ristretto255_precomputed_scalarmul (
  * @param [in] scalar2 A second scalar to multiply by.
  */
 void ristretto255_point_double_scalarmul (
-    ristretto255_point_t combo,
-    const ristretto255_point_t base1,
-    const ristretto255_scalar_t scalar1,
-    const ristretto255_point_t base2,
-    const ristretto255_scalar_t scalar2
+    ristretto255_point_t *combo,
+    const ristretto255_point_t *base1,
+    const ristretto255_scalar_t *scalar1,
+    const ristretto255_point_t *base2,
+    const ristretto255_scalar_t *scalar2
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -552,11 +552,11 @@ void ristretto255_point_double_scalarmul (
  * @param [in] scalar2 A second scalar to multiply by.
  */
 void ristretto255_point_dual_scalarmul (
-    ristretto255_point_t a1,
-    ristretto255_point_t a2,
-    const ristretto255_point_t base1,
-    const ristretto255_scalar_t scalar1,
-    const ristretto255_scalar_t scalar2
+    ristretto255_point_t *a1,
+    ristretto255_point_t *a2,
+    const ristretto255_point_t *base1,
+    const ristretto255_scalar_t *scalar1,
+    const ristretto255_scalar_t *scalar2
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -575,10 +575,10 @@ void ristretto255_point_dual_scalarmul (
  * used.  It is designed for signature verification.
  */
 void ristretto255_base_double_scalarmul_non_secret (
-    ristretto255_point_t combo,
-    const ristretto255_scalar_t scalar1,
-    const ristretto255_point_t base2,
-    const ristretto255_scalar_t scalar2
+    ristretto255_point_t *combo,
+    const ristretto255_scalar_t *scalar1,
+    const ristretto255_point_t *base2,
+    const ristretto255_scalar_t *scalar2
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -591,9 +591,9 @@ void ristretto255_base_double_scalarmul_non_secret (
  * @param [in] pick_b If nonzero, choose point b.
  */
 void ristretto255_point_cond_sel (
-    ristretto255_point_t out,
-    const ristretto255_point_t a,
-    const ristretto255_point_t b,
+    ristretto255_point_t *out,
+    const ristretto255_point_t *a,
+    const ristretto255_point_t *b,
     ristretto_word_t pick_b
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
@@ -607,9 +607,9 @@ void ristretto255_point_cond_sel (
  * @param [in] pick_b If nonzero, choose scalar b.
  */
 void ristretto255_scalar_cond_sel (
-    ristretto255_scalar_t out,
-    const ristretto255_scalar_t a,
-    const ristretto255_scalar_t b,
+    ristretto255_scalar_t *out,
+    const ristretto255_scalar_t *a,
+    const ristretto255_scalar_t *b,
     ristretto_word_t pick_b
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
@@ -621,7 +621,7 @@ void ristretto255_scalar_cond_sel (
  * @retval RISTRETTO_FALSE The point is invalid.
  */
 ristretto_bool_t ristretto255_point_valid (
-    const ristretto255_point_t to_test
+    const ristretto255_point_t *to_test
 ) RISTRETTO_WARN_UNUSED RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -632,8 +632,8 @@ ristretto_bool_t ristretto255_point_valid (
  * @param [in] p The point to torque.
  */
 void ristretto255_point_debugging_torque (
-    ristretto255_point_t q,
-    const ristretto255_point_t p
+    ristretto255_point_t *q,
+    const ristretto255_point_t *p
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
 /**
@@ -646,8 +646,8 @@ void ristretto255_point_debugging_torque (
  * @param [in] factor Serialized GF factor to scale.
  */
 void ristretto255_point_debugging_pscale (
-    ristretto255_point_t q,
-    const ristretto255_point_t p,
+    ristretto255_point_t *q,
+    const ristretto255_point_t *p,
     const unsigned char factor[RISTRETTO255_SER_BYTES]
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
@@ -680,7 +680,7 @@ void ristretto255_point_debugging_pscale (
  * @param [out] pt The data hashed to the curve.
  */
 void ristretto255_point_from_hash_nonuniform (
-    ristretto255_point_t pt,
+    ristretto255_point_t *pt,
     const unsigned char hashed_data[RISTRETTO255_HASH_BYTES]
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
@@ -693,7 +693,7 @@ void ristretto255_point_from_hash_nonuniform (
  * @param [out] pt The data hashed to the curve.
  */
 void ristretto255_point_from_hash_uniform (
-    ristretto255_point_t pt,
+    ristretto255_point_t *pt,
     const unsigned char hashed_data[2*RISTRETTO255_HASH_BYTES]
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE;
 
@@ -727,7 +727,7 @@ void ristretto255_point_from_hash_uniform (
  */
 ristretto_error_t ristretto255_invert_elligator_nonuniform (
     unsigned char recovered_hash[RISTRETTO255_HASH_BYTES],
-    const ristretto255_point_t pt,
+    const ristretto255_point_t *pt,
     uint32_t which
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE RISTRETTO_WARN_UNUSED;
 
@@ -751,20 +751,20 @@ ristretto_error_t ristretto255_invert_elligator_nonuniform (
  */
 ristretto_error_t ristretto255_invert_elligator_uniform (
     unsigned char recovered_hash[2*RISTRETTO255_HASH_BYTES],
-    const ristretto255_point_t pt,
+    const ristretto255_point_t *pt,
     uint32_t which
 ) RISTRETTO_NONNULL RISTRETTO_NOINLINE RISTRETTO_WARN_UNUSED;
 
 /** Securely erase a scalar. */
 void ristretto255_scalar_destroy (
-    ristretto255_scalar_t scalar
+    ristretto255_scalar_t *scalar
 ) RISTRETTO_NONNULL;
 
 /** Securely erase a point by overwriting it with zeros.
  * @warning This causes the point object to become invalid.
  */
 void ristretto255_point_destroy (
-    ristretto255_point_t point
+    ristretto255_point_t *point
 ) RISTRETTO_NONNULL;
 
 /** Securely erase a precomputed table by overwriting it with zeros.

--- a/src/arch/32/f_impl.c
+++ b/src/arch/32/f_impl.c
@@ -5,7 +5,7 @@
 #include <ristretto255.h>
 #include "f_field.h"
 
-void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
+void gf_mul (gf_25519_t *__restrict__ cs, const gf_25519_t *as, const gf_25519_t *bs) {
     const uint32_t *a = as->limb, *b = bs->limb, maske = ((1<<26)-1), masko = ((1<<25)-1);
 
     uint32_t bh[9];
@@ -52,7 +52,7 @@ void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
     c[1] += accum;
 }
 
-void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
+void gf_mulw_unsigned (gf_25519_t *__restrict__ cs, const gf_25519_t *as, uint32_t b) {
     const uint32_t *a = as->limb, maske = ((1<<26)-1), masko = ((1<<25)-1);
     uint32_t *c = cs->limb;
     uint64_t accum = widemul(b, a[0]);
@@ -84,7 +84,7 @@ void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
     c[1] += accum;
 }
 
-void gf_sqr (gf_s *__restrict__ cs, const gf as) {
+void gf_sqr (gf_25519_t *__restrict__ cs, const gf_25519_t *as) {
     gf_mul(cs,as,as); /* Performs better with dedicated square */
 }
 

--- a/src/arch/32/f_impl.h
+++ b/src/arch/32/f_impl.h
@@ -8,19 +8,19 @@
 
 #define LIMB_PLACE_VALUE(i) (((i)&1)?25:26)
 
-void gf_add_RAW (gf out, const gf a, const gf b) {
+void gf_add_RAW (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b) {
     for (unsigned int i=0; i<10; i++) {
         out->limb[i] = a->limb[i] + b->limb[i];
     }
 }
 
-void gf_sub_RAW (gf out, const gf a, const gf b) {
+void gf_sub_RAW (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b) {
     for (unsigned int i=0; i<10; i++) {
         out->limb[i] = a->limb[i] - b->limb[i];
     }
 }
 
-void gf_bias (gf a, int amt) {
+void gf_bias (gf_25519_t *a, int amt) {
     uint32_t coe = ((1ull<<26)-1)*amt, coo = ((1ull<<25)-1)*amt, co0 = coe-18*amt;
     for (unsigned int i=0; i<10; i+=2) {
         a->limb[i] += ((i==0) ? co0 : coe);
@@ -28,7 +28,7 @@ void gf_bias (gf a, int amt) {
     }
 }
 
-void gf_weak_reduce (gf a) {
+void gf_weak_reduce (gf_25519_t *a) {
     uint32_t maske = (1ull<<26) - 1, masko = (1ull<<25) - 1;
     uint32_t tmp = a->limb[9] >> 25;
     for (unsigned int i=8; i>0; i-=2) {

--- a/src/arch/ref64/f_impl.c
+++ b/src/arch/ref64/f_impl.c
@@ -5,7 +5,7 @@
 #include <ristretto255.h>
 #include "f_field.h"
 
-void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
+void gf_mul (gf_25519_t *__restrict__ cs, const gf_25519_t *as, const gf_25519_t *bs) {
     const uint64_t *a = as->limb, *b = bs->limb, mask = ((1ull<<51)-1);
 
     uint64_t bh[4];
@@ -35,7 +35,7 @@ void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
     c[1] += accum;
 }
 
-void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
+void gf_mulw_unsigned (gf_25519_t *__restrict__ cs, const gf_25519_t *as, uint32_t b) {
     const uint64_t *a = as->limb, mask = ((1ull<<51)-1);
     int i;
 
@@ -57,6 +57,6 @@ void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
     c[1] += accum;
 }
 
-void gf_sqr (gf_s *__restrict__ cs, const gf as) {
+void gf_sqr (gf_25519_t *__restrict__ cs, const gf_25519_t *as) {
     gf_mul(cs,as,as); /* Performs better with dedicated square */
 }

--- a/src/arch/ref64/f_impl.h
+++ b/src/arch/ref64/f_impl.h
@@ -7,14 +7,14 @@
 
 #define LIMB_PLACE_VALUE(i) 51
 
-void gf_add_RAW (gf out, const gf a, const gf b) {
+void gf_add_RAW (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b) {
     for (unsigned int i=0; i<5; i++) {
         out->limb[i] = a->limb[i] + b->limb[i];
     }
     gf_weak_reduce(out);
 }
 
-void gf_sub_RAW (gf out, const gf a, const gf b) {
+void gf_sub_RAW (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b) {
     uint64_t co1 = ((1ull<<51)-1)*2, co2 = co1-36;
     for (unsigned int i=0; i<5; i++) {
         out->limb[i] = a->limb[i] - b->limb[i] + ((i==0) ? co2 : co1);
@@ -22,12 +22,12 @@ void gf_sub_RAW (gf out, const gf a, const gf b) {
     gf_weak_reduce(out);
 }
 
-void gf_bias (gf a, int amt) {
+void gf_bias (gf_25519_t *a, int amt) {
     (void) a;
     (void) amt;
 }
 
-void gf_weak_reduce (gf a) {
+void gf_weak_reduce (gf_25519_t *a) {
     uint64_t mask = (1ull<<51) - 1;
     uint64_t tmp = a->limb[4] >> 51;
     for (unsigned int i=4; i>0; i--) {

--- a/src/arch/x86_64/f_impl.c
+++ b/src/arch/x86_64/f_impl.c
@@ -6,7 +6,7 @@
 #include "f_field.h"
 
 /** Requires: input limbs < 9*2^51 */
-void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
+void gf_mul (gf_25519_t *__restrict__ cs, const gf_25519_t *as, const gf_25519_t *bs) {
     const uint64_t *a = as->limb, *b = bs->limb, mask = ((1ull<<51)-1);
     uint64_t *c = cs->limb;
 
@@ -82,7 +82,7 @@ void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs) {
     c[1] = c1 + (accum1>>51);
 }
 
-void gf_sqr (gf_s *__restrict__ cs, const gf as) {
+void gf_sqr (gf_25519_t *__restrict__ cs, const gf_25519_t *as) {
     const uint64_t *a = as->limb, mask = ((1ull<<51)-1);
     uint64_t *c = cs->limb;
 
@@ -141,7 +141,7 @@ void gf_sqr (gf_s *__restrict__ cs, const gf as) {
     c[1] = c1 + (accum1>>51);
 }
 
-void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b) {
+void gf_mulw_unsigned (gf_25519_t *__restrict__ cs, const gf_25519_t *as, uint32_t b) {
     const uint64_t *a = as->limb, mask = ((1ull<<51)-1);
     uint64_t *c = cs->limb;
 

--- a/src/arch/x86_64/f_impl.h
+++ b/src/arch/x86_64/f_impl.h
@@ -7,26 +7,26 @@
 
 #define LIMB_PLACE_VALUE(i) 51
 
-void gf_add_RAW (gf out, const gf a, const gf b) {
+void gf_add_RAW (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b) {
     for (unsigned int i=0; i<5; i++) {
         out->limb[i] = a->limb[i] + b->limb[i];
     }
 }
 
-void gf_sub_RAW (gf out, const gf a, const gf b) {
+void gf_sub_RAW (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b) {
     for (unsigned int i=0; i<5; i++) {
         out->limb[i] = a->limb[i] - b->limb[i];
     }
 }
 
-void gf_bias (gf a, int amt) {
+void gf_bias (gf_25519_t *a, int amt) {
     a->limb[0] += ((uint64_t)(amt)<<52) - 38*amt;
     for (unsigned int i=1; i<5; i++) {
         a->limb[i] += ((uint64_t)(amt)<<52)-2*amt;
     }
 }
 
-void gf_weak_reduce (gf a) {
+void gf_weak_reduce (gf_25519_t *a) {
     uint64_t mask = (1ull<<51) - 1;
     uint64_t tmp = a->limb[4] >> 51;
     for (unsigned int i=4; i>0; i--) {

--- a/src/elligator.c
+++ b/src/elligator.c
@@ -14,85 +14,87 @@
 #include "field.h"
 
 #define point_t ristretto255_point_t
-static const int EDWARDS_D = -121665;
 
-extern const gf RISTRETTO255_FACTOR;
+extern const int RISTRETTO255_EDWARDS_D;
+#define EDWARDS_D RISTRETTO255_EDWARDS_D
+
+extern const gf_25519_t RISTRETTO255_FACTOR;
 
 extern mask_t ristretto255_deisogenize (
-    gf_s *__restrict__ s,
-    gf_s *__restrict__ inv_el_sum,
-    gf_s *__restrict__ inv_el_m1,
-    const point_t p,
+    gf_25519_t *__restrict__ s,
+    gf_25519_t *__restrict__ inv_el_sum,
+    gf_25519_t *__restrict__ inv_el_m1,
+    const point_t *p,
     mask_t toggle_hibit_s,
     mask_t toggle_altx,
     mask_t toggle_rotation
 );
 
 void ristretto255_point_from_hash_nonuniform (
-    point_t p,
+    point_t *p,
     const unsigned char ser[SER_BYTES]
 ) {
-    gf r0,r,a,b,c,N,e;
+    gf_25519_t r0,r,a,b,c,N,e;
     const uint8_t mask = (uint8_t)(0xFE<<(6));
-    ignore_result(gf_deserialize(r0,ser,0,mask));
-    gf_strong_reduce(r0);
-    gf_sqr(a,r0);
-    gf_mul_qnr(r,a);
+    ignore_result(gf_deserialize(&r0,ser,0,mask));
+    gf_strong_reduce(&r0);
+    gf_sqr(&a,&r0);
+    gf_mul_qnr(&r,&a);
 
     /* Compute D@c := (dr+a-d)(dr-ar-d) with a=1 */
-    gf_sub(a,r,ONE);
-    gf_mulw(b,a,EDWARDS_D); /* dr-d */
-    gf_add(a,b,ONE);
-    gf_sub(b,b,r);
-    gf_mul(c,a,b);
+    gf_sub(&a,&r,&ONE);
+    gf_mulw(&b,&a,EDWARDS_D); /* dr-d */
+    gf_add(&a,&b,&ONE);
+    gf_sub(&b,&b,&r);
+    gf_mul(&c,&a,&b);
 
     /* compute N := (r+1)(a-2d) */
-    gf_add(a,r,ONE);
-    gf_mulw(N,a,1-2*EDWARDS_D);
+    gf_add(&a,&r,&ONE);
+    gf_mulw(&N,&a,1-2*EDWARDS_D);
 
     /* e = +-sqrt(1/ND) or +-r0 * sqrt(qnr/ND) */
-    gf_mul(a,c,N);
-    mask_t square = gf_isr(b,a);
-    gf_cond_sel(c,r0,ONE,square); /* r? = square ? 1 : r0 */
-    gf_mul(e,b,c);
+    gf_mul(&a,&c,&N);
+    mask_t square = gf_isr(&b,&a);
+    gf_cond_sel(&c,&r0,&ONE,square); /* r? = square ? 1 : r0 */
+    gf_mul(&e,&b,&c);
 
     /* s@a = +-|N.e| */
-    gf_mul(a,N,e);
-    gf_cond_neg(a,gf_lobit(a) ^ ~square);
+    gf_mul(&a,&N,&e);
+    gf_cond_neg(&a,gf_lobit(&a) ^ ~square);
 
     /* t@b = -+ cN(r-1)((a-2d)e)^2 - 1 */
-    gf_mulw(c,e,1-2*EDWARDS_D); /* (a-2d)e */
-    gf_sqr(b,c);
-    gf_sub(e,r,ONE);
-    gf_mul(c,b,e);
-    gf_mul(b,c,N);
-    gf_cond_neg(b,square);
-    gf_sub(b,b,ONE);
+    gf_mulw(&c,&e,1-2*EDWARDS_D); /* (a-2d)e */
+    gf_sqr(&b,&c);
+    gf_sub(&e,&r,&ONE);
+    gf_mul(&c,&b,&e);
+    gf_mul(&b,&c,&N);
+    gf_cond_neg(&b,square);
+    gf_sub(&b,&b,&ONE);
 
     /* isogenize */
-    gf_mul(c,a,SQRT_MINUS_ONE);
-    gf_copy(a,c);
+    gf_mul(&c,&a,&SQRT_MINUS_ONE);
+    gf_copy(&a,&c);
 
-    gf_sqr(c,a); /* s^2 */
-    gf_add(a,a,a); /* 2s */
-    gf_add(e,c,ONE);
-    gf_mul(p->t,a,e); /* 2s(1+s^2) */
-    gf_mul(p->x,a,b); /* 2st */
-    gf_sub(a,ONE,c);
-    gf_mul(p->y,e,a); /* (1+s^2)(1-s^2) */
-    gf_mul(p->z,a,b); /* (1-s^2)t */
+    gf_sqr(&c,&a); /* s^2 */
+    gf_add(&a,&a,&a); /* 2s */
+    gf_add(&e,&c,&ONE);
+    gf_mul(&p->t,&a,&e); /* 2s(1+s^2) */
+    gf_mul(&p->x,&a,&b); /* 2st */
+    gf_sub(&a,&ONE,&c);
+    gf_mul(&p->y,&e,&a); /* (1+s^2)(1-s^2) */
+    gf_mul(&p->z,&a,&b); /* (1-s^2)t */
 
     assert(ristretto255_point_valid(p));
 }
 
 void ristretto255_point_from_hash_uniform (
-    point_t pt,
+    point_t *pt,
     const unsigned char hashed_data[2*SER_BYTES]
 ) {
     point_t pt2;
     ristretto255_point_from_hash_nonuniform(pt,hashed_data);
-    ristretto255_point_from_hash_nonuniform(pt2,&hashed_data[SER_BYTES]);
-    ristretto255_point_add(pt,pt,pt2);
+    ristretto255_point_from_hash_nonuniform(&pt2,&hashed_data[SER_BYTES]);
+    ristretto255_point_add(pt,pt,&pt2);
 }
 
 /* Elligator_onto:
@@ -106,7 +108,7 @@ void ristretto255_point_from_hash_uniform (
 ristretto_error_t
 ristretto255_invert_elligator_nonuniform (
     unsigned char recovered_hash[SER_BYTES],
-    const point_t p,
+    const point_t *p,
     uint32_t hint_
 ) {
     mask_t hint = hint_;
@@ -117,39 +119,39 @@ ristretto255_invert_elligator_nonuniform (
          * change this mask extraction.
          */
         sgn_ed_T = -(hint>>3 & 1);
-    gf a,b,c;
-    ristretto255_deisogenize(a,b,c,p,sgn_s,sgn_altx,sgn_ed_T);
+    gf_25519_t a,b,c;
+    ristretto255_deisogenize(&a,&b,&c,p,sgn_s,sgn_altx,sgn_ed_T);
 
-    mask_t is_identity = gf_eq(p->t,ZERO);
+    mask_t is_identity = gf_eq(&p->t,&ZERO);
 
     /* Terrible, terrible special casing due to lots of 0/0 is deisogenize
      * Basically we need to generate -D and +- i*RISTRETTO255_FACTOR
      */
-    gf_mul_i(a,RISTRETTO255_FACTOR);
-    gf_cond_sel(b,b,ONE,is_identity);
-    gf_cond_neg(a,sgn_altx);
-    gf_cond_sel(c,c,a,is_identity & sgn_ed_T);
-    gf_cond_sel(c,c,ZERO,is_identity & ~sgn_ed_T);
-    gf_mulw(a,ONE,-EDWARDS_D);
-    gf_cond_sel(c,c,a,is_identity & ~sgn_ed_T &~ sgn_altx);
+    gf_mul_i(&a,&RISTRETTO255_FACTOR);
+    gf_cond_sel(&b,&b,&ONE,is_identity);
+    gf_cond_neg(&a,sgn_altx);
+    gf_cond_sel(&c,&c,&a,is_identity & sgn_ed_T);
+    gf_cond_sel(&c,&c,&ZERO,is_identity & ~sgn_ed_T);
+    gf_mulw(&a,&ONE,-EDWARDS_D);
+    gf_cond_sel(&c,&c,&a,is_identity & ~sgn_ed_T &~ sgn_altx);
 
-    gf_mulw(a,b,-EDWARDS_D);
-    gf_add(b,a,b);
-    gf_sub(a,a,c);
-    gf_add(b,b,c);
-    gf_cond_swap(a,b,sgn_s);
-    gf_mul_qnr(c,b);
-    gf_mul(b,c,a);
-    mask_t succ = gf_isr(c,b);
-    succ |= gf_eq(b,ZERO);
-    gf_mul(b,c,a);
+    gf_mulw(&a,&b,-EDWARDS_D);
+    gf_add(&b,&a,&b);
+    gf_sub(&a,&a,&c);
+    gf_add(&b,&b,&c);
+    gf_cond_swap(&a,&b,sgn_s);
+    gf_mul_qnr(&c,&b);
+    gf_mul(&b,&c,&a);
+    mask_t succ = gf_isr(&c,&b);
+    succ |= gf_eq(&b,&ZERO);
+    gf_mul(&b,&c,&a);
 
-    gf_cond_neg(b, sgn_r0^gf_lobit(b));
+    gf_cond_neg(&b, sgn_r0^gf_lobit(&b));
     /* Eliminate duplicate values for identity ... */
-    succ &= ~(gf_eq(b,ZERO) & (sgn_r0 | sgn_s));
+    succ &= ~(gf_eq(&b,&ZERO) & (sgn_r0 | sgn_s));
     //     succ &= ~(is_identity & sgn_ed_T); /* NB: there are no preimages of rotated identity. */
 
-    gf_serialize(recovered_hash,b,1);
+    gf_serialize(recovered_hash,&b,1);
     recovered_hash[SER_BYTES-1] ^= (hint>>4)<<7;
 
     return ristretto_succeed_if(mask_to_bool(succ));
@@ -158,11 +160,11 @@ ristretto255_invert_elligator_nonuniform (
 ristretto_error_t
 ristretto255_invert_elligator_uniform (
     unsigned char partial_hash[2*SER_BYTES],
-    const point_t p,
+    const point_t *p,
     uint32_t hint
 ) {
     point_t pt2;
-    ristretto255_point_from_hash_nonuniform(pt2,&partial_hash[SER_BYTES]);
-    ristretto255_point_sub(pt2,p,pt2);
-    return ristretto255_invert_elligator_nonuniform(partial_hash,pt2,hint);
+    ristretto255_point_from_hash_nonuniform(&pt2,&partial_hash[SER_BYTES]);
+    ristretto255_point_sub(&pt2,p,&pt2);
+    return ristretto255_invert_elligator_nonuniform(partial_hash,&pt2,hint);
 }

--- a/src/f_arithmetic.c
+++ b/src/f_arithmetic.c
@@ -13,40 +13,40 @@
 #include "constant_time.h"
 
 /* Guarantee: a^2 x = 0 if x = 0; else a^2 x = 1 or SQRT_MINUS_ONE; */
-mask_t gf_isr (gf a, const gf x) {
-    gf L0, L1, L2, L3;
+mask_t gf_isr (gf_25519_t *a, const gf_25519_t *x) {
+    gf_25519_t L0, L1, L2, L3;
 
-    gf_sqr (L0, x);
-    gf_mul (L1, L0, x);
-    gf_sqr (L0, L1);
-    gf_mul (L1, L0, x);
-    gf_sqrn(L0, L1, 3);
-    gf_mul (L2, L0, L1);
-    gf_sqrn(L0, L2, 6);
-    gf_mul (L1, L2, L0);
-    gf_sqr (L2, L1);
-    gf_mul (L0, L2, x);
-    gf_sqrn(L2, L0, 12);
-    gf_mul (L0, L2, L1);
-    gf_sqrn(L2, L0, 25);
-    gf_mul (L3, L2, L0);
-    gf_sqrn(L2, L3, 25);
-    gf_mul (L1, L2, L0);
-    gf_sqrn(L2, L1, 50);
-    gf_mul (L0, L2, L3);
-    gf_sqrn(L2, L0, 125);
-    gf_mul (L3, L2, L0);
-    gf_sqrn(L2, L3, 2);
-    gf_mul (L0, L2, x);
+    gf_sqr (&L0, x);
+    gf_mul (&L1, &L0, x);
+    gf_sqr (&L0, &L1);
+    gf_mul (&L1, &L0, x);
+    gf_sqrn(&L0, &L1, 3);
+    gf_mul (&L2, &L0, &L1);
+    gf_sqrn(&L0, &L2, 6);
+    gf_mul (&L1, &L2, &L0);
+    gf_sqr (&L2, &L1);
+    gf_mul (&L0, &L2, x);
+    gf_sqrn(&L2, &L0, 12);
+    gf_mul (&L0, &L2, &L1);
+    gf_sqrn(&L2, &L0, 25);
+    gf_mul (&L3, &L2, &L0);
+    gf_sqrn(&L2, &L3, 25);
+    gf_mul (&L1, &L2, &L0);
+    gf_sqrn(&L2, &L1, 50);
+    gf_mul (&L0, &L2, &L3);
+    gf_sqrn(&L2, &L0, 125);
+    gf_mul (&L3, &L2, &L0);
+    gf_sqrn(&L2, &L3, 2);
+    gf_mul (&L0, &L2, x);
 
-    gf_sqr (L2, L0);
-    gf_mul (L3, L2, x);
-    gf_add(L1,L3,ONE);
-    mask_t one = gf_eq(L3,ONE);
-    mask_t succ = one | gf_eq(L1,ZERO);
-    mask_t qr   = one | gf_eq(L3,SQRT_MINUS_ONE);
+    gf_sqr (&L2, &L0);
+    gf_mul (&L3, &L2, x);
+    gf_add(&L1,&L3,&ONE);
+    mask_t one = gf_eq(&L3,&ONE);
+    mask_t succ = one | gf_eq(&L1, &ZERO);
+    mask_t qr   = one | gf_eq(&L3, &SQRT_MINUS_ONE);
 
-    constant_time_select(L2, SQRT_MINUS_ONE, ONE, sizeof(L2), qr, 0);
-    gf_mul (a,L2,L0);
+    constant_time_select(&L2, &SQRT_MINUS_ONE, &ONE, sizeof(L2), qr, 0);
+    gf_mul (a,&L2,&L0);
     return succ;
 }

--- a/src/f_field.h
+++ b/src/f_field.h
@@ -18,31 +18,9 @@
 
 #include "word.h"
 
-#define SER_BYTES         32
+#define SER_BYTES         RISTRETTO255_SER_BYTES
 #define GF_LIT_LIMB_BITS  51
 #define GF_BITS           255
-#define ZERO              gf_25519_ZERO
-#define ONE               gf_25519_ONE
-#define MODULUS           gf_25519_MODULUS
-#define gf                gf_25519_t
-#define gf_s              gf_25519_s
-#define gf_eq             gf_25519_eq
-#define gf_hibit          gf_25519_hibit
-#define gf_lobit          gf_25519_lobit
-#define gf_copy           gf_25519_copy
-#define gf_add            gf_25519_add
-#define gf_sub            gf_25519_sub
-#define gf_add_RAW        gf_25519_add_RAW
-#define gf_sub_RAW        gf_25519_sub_RAW
-#define gf_bias           gf_25519_bias
-#define gf_weak_reduce    gf_25519_weak_reduce
-#define gf_strong_reduce  gf_25519_strong_reduce
-#define gf_mul            gf_25519_mul
-#define gf_sqr            gf_25519_sqr
-#define gf_mulw_unsigned  gf_25519_mulw_unsigned
-#define gf_isr            gf_25519_isr
-#define gf_serialize      gf_25519_serialize
-#define gf_deserialize    gf_25519_deserialize
 
 #define INLINE_UNUSED __inline__ __attribute__((unused,always_inline))
 
@@ -51,25 +29,25 @@ extern "C" {
 #endif
 
 /* Defined below in f_impl.h */
-static INLINE_UNUSED void gf_copy (gf out, const gf a) { *out = *a; }
-static INLINE_UNUSED void gf_add_RAW (gf out, const gf a, const gf b);
-static INLINE_UNUSED void gf_sub_RAW (gf out, const gf a, const gf b);
-static INLINE_UNUSED void gf_bias (gf inout, int amount);
-static INLINE_UNUSED void gf_weak_reduce (gf inout);
+static INLINE_UNUSED void gf_copy (gf_25519_t *out, const gf_25519_t *a) { *out = *a; }
+static INLINE_UNUSED void gf_add_RAW (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b);
+static INLINE_UNUSED void gf_sub_RAW (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b);
+static INLINE_UNUSED void gf_bias (gf_25519_t *inout, int amount);
+static INLINE_UNUSED void gf_weak_reduce (gf_25519_t *inout);
 
-void gf_strong_reduce (gf inout);
-void gf_add (gf out, const gf a, const gf b);
-void gf_sub (gf out, const gf a, const gf b);
-void gf_mul (gf_s *__restrict__ out, const gf a, const gf b);
-void gf_mulw_unsigned (gf_s *__restrict__ out, const gf a, uint32_t b);
-void gf_sqr (gf_s *__restrict__ out, const gf a);
-mask_t gf_isr(gf a, const gf x); /** a^2 x = 1, QNR, or 0 if x=0.  Return true if successful */
-mask_t gf_eq (const gf x, const gf y);
-mask_t gf_lobit (const gf x);
-mask_t gf_hibit (const gf x);
+void gf_strong_reduce (gf_25519_t *inout);
+void gf_add (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b);
+void gf_sub (gf_25519_t *out, const gf_25519_t *a, const gf_25519_t *b);
+void gf_mul (gf_25519_t *__restrict__ out, const gf_25519_t *a, const gf_25519_t *b);
+void gf_mulw_unsigned (gf_25519_t *__restrict__ out, const gf_25519_t *a, uint32_t b);
+void gf_sqr (gf_25519_t *__restrict__ out, const gf_25519_t *a);
+mask_t gf_isr(gf_25519_t *a, const gf_25519_t *x); /** a^2 x = 1, QNR, or 0 if x=0.  Return true if successful */
+mask_t gf_eq (const gf_25519_t *x, const gf_25519_t *y);
+mask_t gf_lobit (const gf_25519_t *x);
+mask_t gf_hibit (const gf_25519_t *x);
 
-void gf_serialize (uint8_t *serial, const gf x,int with_highbit);
-mask_t gf_deserialize (gf x, const uint8_t serial[SER_BYTES],int with_hibit,uint8_t hi_nmask);
+void gf_serialize (uint8_t *serial, const gf_25519_t *x,int with_highbit);
+mask_t gf_deserialize (gf_25519_t *x, const uint8_t serial[SER_BYTES], int with_hibit, uint8_t hi_nmask);
 
 
 #ifdef __cplusplus
@@ -78,13 +56,13 @@ mask_t gf_deserialize (gf x, const uint8_t serial[SER_BYTES],int with_hibit,uint
 
 #include "f_impl.h" /* Bring in the inline implementations */
 
-extern const gf SQRT_MINUS_ONE;
+extern const gf_25519_t SQRT_MINUS_ONE;
 
 #ifndef LIMBPERM
   #define LIMBPERM(i) (i)
 #endif
 #define LIMB_MASK(i) (((1ull)<<LIMB_PLACE_VALUE(i))-1)
 
-static const gf ZERO = {{{0}}}, ONE = {{{ [LIMBPERM(0)] = 1 }}};
+static const gf_25519_t ZERO = {{0}}, ONE = {{ [LIMBPERM(0)] = 1 }};
 
 #endif /* __P25519_F_FIELD_H__ */

--- a/src/field.h
+++ b/src/field.h
@@ -16,79 +16,79 @@
 
 /** Square x, n times. */
 static RISTRETTO_INLINE void gf_sqrn (
-    gf_s *__restrict__ y,
-    const gf x,
+    gf_25519_t *__restrict__ y,
+    const gf_25519_t *x,
     int n
 ) {
-    gf tmp;
+    gf_25519_t tmp;
     assert(n>0);
     if (n&1) {
         gf_sqr(y,x);
         n--;
     } else {
-        gf_sqr(tmp,x);
-        gf_sqr(y,tmp);
+        gf_sqr(&tmp,x);
+        gf_sqr(y,&tmp);
         n-=2;
     }
     for (; n; n-=2) {
-        gf_sqr(tmp,y);
-        gf_sqr(y,tmp);
+        gf_sqr(&tmp,y);
+        gf_sqr(y,&tmp);
     }
 }
 
 #define gf_add_nr gf_add_RAW
 
 /** Subtract mod p.  Bias by 2 and don't reduce  */
-static inline void gf_sub_nr ( gf c, const gf a, const gf b ) {
+static inline void gf_sub_nr ( gf_25519_t *c, const gf_25519_t *a, const gf_25519_t *b ) {
     gf_sub_RAW(c,a,b);
     gf_bias(c, 2);
     if (GF_HEADROOM < 3) gf_weak_reduce(c);
 }
 
 /** Subtract mod p. Bias by amt but don't reduce.  */
-static inline void gf_subx_nr ( gf c, const gf a, const gf b, int amt ) {
+static inline void gf_subx_nr ( gf_25519_t *c, const gf_25519_t *a, const gf_25519_t *b, int amt ) {
     gf_sub_RAW(c,a,b);
     gf_bias(c, amt);
     if (GF_HEADROOM < amt+1) gf_weak_reduce(c);
 }
 
 /** Mul by signed int.  Not constant-time WRT the sign of that int. */
-static inline void gf_mulw(gf c, const gf a, int32_t w) {
+static inline void gf_mulw(gf_25519_t *c, const gf_25519_t *a, int32_t w) {
     if (w>0) {
         gf_mulw_unsigned(c, a, w);
     } else {
         gf_mulw_unsigned(c, a, -w);
-        gf_sub(c,ZERO,c);
+        gf_sub(c,&ZERO,c);
     }
 }
 
 /** Constant time, x = is_z ? z : y */
-static inline void gf_cond_sel(gf x, const gf y, const gf z, mask_t is_z) {
-    constant_time_select(x,y,z,sizeof(gf),is_z,0);
+static inline void gf_cond_sel(gf_25519_t *x, const gf_25519_t *y, const gf_25519_t *z, mask_t is_z) {
+    constant_time_select(x,y,z,sizeof(gf_25519_t),is_z,0);
 }
 
 /** Constant time, if (neg) x=-x; */
-static inline void gf_cond_neg(gf x, mask_t neg) {
-    gf y;
-    gf_sub(y,ZERO,x);
-    gf_cond_sel(x,x,y,neg);
+static inline void gf_cond_neg(gf_25519_t *x, mask_t neg) {
+    gf_25519_t y;
+    gf_sub(&y,&ZERO,x);
+    gf_cond_sel(x,x,&y,neg);
 }
 
 /** Constant time, if (swap) (x,y) = (y,x); */
 static inline void
-gf_cond_swap(gf x, gf_s *__restrict__ y, mask_t swap) {
-    constant_time_cond_swap(x,y,sizeof(gf_s),swap);
+gf_cond_swap(gf_25519_t *x, gf_25519_t *__restrict__ y, mask_t swap) {
+    constant_time_cond_swap(x,y,sizeof(gf_25519_t),swap);
 }
 
-static RISTRETTO_INLINE void gf_mul_qnr(gf_s *__restrict__ out, const gf x) {
+static RISTRETTO_INLINE void gf_mul_qnr(gf_25519_t *__restrict__ out, const gf_25519_t *x) {
     /* r = QNR * r0^2 */
-    gf_mul(out,x,SQRT_MINUS_ONE);
+    gf_mul(out,x,&SQRT_MINUS_ONE);
 }
 
-static RISTRETTO_INLINE void gf_div_qnr(gf_s *__restrict__ out, const gf x) {
+static RISTRETTO_INLINE void gf_div_qnr(gf_25519_t *__restrict__ out, const gf_25519_t *x) {
     /* r = QNR * r0^2 */
-    gf_mul(out,x,SQRT_MINUS_ONE);
-    gf_sub(out,ZERO,out);
+    gf_mul(out,x,&SQRT_MINUS_ONE);
+    gf_sub(out,&ZERO,out);
 }
 
 #define gf_mul_i gf_mul_qnr

--- a/src/ristretto.c
+++ b/src/ristretto.c
@@ -30,41 +30,33 @@
 #define RISTRETTO_WNAF_FIXED_TABLE_BITS 5
 #define RISTRETTO_WNAF_VAR_TABLE_BITS 3
 
-static const int EDWARDS_D = -121665;
-static const scalar_t point_scalarmul_adjustment = {{{
+const int RISTRETTO255_EDWARDS_D = -121665;
+static const scalar_t point_scalarmul_adjustment = {{
     SC_LIMB(0xd6ec31748d98951c), SC_LIMB(0xc6ef5bf4737dcf70), SC_LIMB(0xfffffffffffffffe), SC_LIMB(0x0fffffffffffffff)
-}}}, precomputed_scalarmul_adjustment = {{{
+}}, precomputed_scalarmul_adjustment = {{
     SC_LIMB(0x977f4a4775473484), SC_LIMB(0x6de72ae98b3ab623), SC_LIMB(0xffffffffffffffff), SC_LIMB(0x0fffffffffffffff)
-}}};
+}};
 
-const gf RISTRETTO255_FACTOR = {FIELD_LITERAL(
+const gf_25519_t RISTRETTO255_FACTOR = FIELD_LITERAL(
     0x702557fa2bf03, 0x514b7d1a82cc6, 0x7f89efd8b43a7, 0x1aef49ec23700, 0x079376fa30500
-)};
+);
 
-#define TWISTED_D (-(EDWARDS_D))
+#define TWISTED_D (-(RISTRETTO255_EDWARDS_D))
 
-#if TWISTED_D < 0
-#define EFF_D (-(TWISTED_D))
-#define NEG_D 1
-#else
-#define EFF_D TWISTED_D
-#define NEG_D 0
-#endif
-
-extern const gf SQRT_MINUS_ONE;
+extern const gf_25519_t SQRT_MINUS_ONE;
 
 #define WBITS RISTRETTO_WORD_BITS /* NB this may be different from ARCH_WORD_BITS */
 
 extern const point_t ristretto255_point_base;
 
 /* Projective Niels coordinates */
-typedef struct { gf a, b, c; } niels_s, niels_t[1];
-typedef struct { niels_t n; gf z; } VECTOR_ALIGNED pniels_s, pniels_t[1];
+typedef struct { gf_25519_t a, b, c; } niels_t;
+typedef struct { niels_t n; gf_25519_t z; } VECTOR_ALIGNED pniels_t;
 
 /* Precomputed base */
 struct precomputed_s { niels_t table [COMBS_N<<(COMBS_T-1)]; };
 
-extern const gf ristretto255_precomputed_base_as_fe[];
+extern const gf_25519_t ristretto255_precomputed_base_as_fe[];
 const precomputed_s *ristretto255_precomputed_base =
     (const precomputed_s *) &ristretto255_precomputed_base_as_fe;
 
@@ -73,392 +65,381 @@ const size_t ristretto255_alignof_precomputed_s = sizeof(big_register_t);
 
 /** Inverse. */
 static void
-gf_invert(gf y, const gf x, int assert_nonzero) {
-    gf t1, t2;
-    gf_sqr(t1, x); // o^2
-    mask_t ret = gf_isr(t2, t1); // +-1/sqrt(o^2) = +-1/o
+gf_invert(gf_25519_t *y, const gf_25519_t *x, int assert_nonzero) {
+    gf_25519_t t1, t2;
+    gf_sqr(&t1, x); // o^2
+    mask_t ret = gf_isr(&t2, &t1); // +-1/sqrt(o^2) = +-1/o
     (void)ret;
     if (assert_nonzero) assert(ret);
-    gf_sqr(t1, t2);
-    gf_mul(t2, t1, x); // not direct to y in case of alias.
-    gf_copy(y, t2);
+    gf_sqr(&t1, &t2);
+    gf_mul(&t2, &t1, x); // not direct to y in case of alias.
+    gf_copy(y, &t2);
 }
 
 /** identity = (0,1) */
-const point_t ristretto255_point_identity = {{{{{0}}},{{{1}}},{{{1}}},{{{0}}}}};
+const point_t ristretto255_point_identity = {{{0}},{{1}},{{1}},{{0}}};
 
 /* Predeclare because not static: called by elligator */
 void ristretto255_deisogenize (
-    gf_s *__restrict__ s,
-    gf_s *__restrict__ inv_el_sum,
-    gf_s *__restrict__ inv_el_m1,
-    const point_t p,
+    gf_25519_t *__restrict__ s,
+    gf_25519_t *__restrict__ inv_el_sum,
+    gf_25519_t *__restrict__ inv_el_m1,
+    const point_t *p,
     mask_t toggle_s,
     mask_t toggle_altx,
     mask_t toggle_rotation
 );
 
 void ristretto255_deisogenize (
-    gf_s *__restrict__ s,
-    gf_s *__restrict__ inv_el_sum,
-    gf_s *__restrict__ inv_el_m1,
-    const point_t p,
+    gf_25519_t *__restrict__ s,
+    gf_25519_t *__restrict__ inv_el_sum,
+    gf_25519_t *__restrict__ inv_el_m1,
+    const point_t *p,
     mask_t toggle_s,
     mask_t toggle_altx,
     mask_t toggle_rotation
 ) {
     /* More complicated because of rotation */
-    gf t1,t2,t3,t4,t5;
-    gf_add(t1,p->z,p->y);
-    gf_sub(t2,p->z,p->y);
-    gf_mul(t3,t1,t2);      /* t3 = num */
-    gf_mul(t2,p->x,p->y);  /* t2 = den */
-    gf_sqr(t1,t2);
-    gf_mul(t4,t1,t3);
-    gf_mulw(t1,t4,-1-TWISTED_D);
-    gf_isr(t4,t1);         /* isqrt(num*(a-d)*den^2) */
-    gf_mul(t1,t2,t4);
-    gf_mul(t2,t1,RISTRETTO255_FACTOR); /* t2 = "iden" in ristretto.sage */
-    gf_mul(t1,t3,t4);                 /* t1 = "inum" in ristretto.sage */
+    gf_25519_t t1,t2,t3,t4,t5;
+    gf_add(&t1,&p->z,&p->y);
+    gf_sub(&t2,&p->z,&p->y);
+    gf_mul(&t3,&t1,&t2);     /* t3 = num */
+    gf_mul(&t2,&p->x,&p->y); /* t2 = den */
+    gf_sqr(&t1,&t2);
+    gf_mul(&t4,&t1,&t3);
+    gf_mulw(&t1,&t4,-1-TWISTED_D);
+    gf_isr(&t4,&t1);         /* isqrt(num*(a-d)*den^2) */
+    gf_mul(&t1,&t2,&t4);
+    gf_mul(&t2,&t1,&RISTRETTO255_FACTOR); /* t2 = "iden" in ristretto.sage */
+    gf_mul(&t1,&t3,&t4);                  /* t1 = "inum" in ristretto.sage */
 
     /* Calculate altxy = iden*inum*i*t^2*(d-a) */
-    gf_mul(t3,t1,t2);
-    gf_mul_i(t4,t3);
-    gf_mul(t3,t4,p->t);
-    gf_mul(t4,t3,p->t);
-    gf_mulw(t3,t4,TWISTED_D+1);      /* iden*inum*i*t^2*(d-1) */
-    mask_t rotate = toggle_rotation ^ gf_lobit(t3);
+    gf_mul(&t3,&t1,&t2);
+    gf_mul_i(&t4,&t3);
+    gf_mul(&t3,&t4,&p->t);
+    gf_mul(&t4,&t3,&p->t);
+    gf_mulw(&t3,&t4,TWISTED_D+1);         /* iden*inum*i*t^2*(d-1) */
+    mask_t rotate = toggle_rotation ^ gf_lobit(&t3);
 
     /* Rotate if altxy is negative */
-    gf_cond_swap(t1,t2,rotate);
-    gf_mul_i(t4,p->x);
-    gf_cond_sel(t4,p->y,t4,rotate);  /* t4 = "fac" = ix if rotate, else y */
+    gf_cond_swap(&t1,&t2,rotate);
+    gf_mul_i(&t4,&p->x);
+    gf_cond_sel(&t4,&p->y,&t4,rotate);   /* t4 = "fac" = ix if rotate, else y */
 
-    gf_mul_i(t5,RISTRETTO255_FACTOR); /* t5 = imi */
-    gf_mul(t3,t5,t2);                /* iden * imi */
-    gf_mul(t2,t5,t1);
-    gf_mul(t5,t2,p->t);              /* "altx" = iden*imi*t */
-    mask_t negx = gf_lobit(t5) ^ toggle_altx;
+    gf_mul_i(&t5,&RISTRETTO255_FACTOR);  /* t5 = imi */
+    gf_mul(&t3,&t5,&t2);                 /* iden * imi */
+    gf_mul(&t2,&t5,&t1);
+    gf_mul(&t5,&t2,&p->t);               /* "altx" = iden*imi*t */
+    mask_t negx = gf_lobit(&t5) ^ toggle_altx;
 
-    gf_cond_neg(t1,negx^rotate);
-    gf_mul(t2,t1,p->z);
-    gf_add(t2,t2,ONE);
-    gf_mul(inv_el_sum,t2,t4);
-    gf_mul(s,inv_el_sum,t3);
+    gf_cond_neg(&t1,negx^rotate);
+    gf_mul(&t2,&t1,&p->z);
+    gf_add(&t2,&t2,&ONE);
+    gf_mul(inv_el_sum,&t2,&t4);
+    gf_mul(s,inv_el_sum,&t3);
 
     mask_t negs = gf_lobit(s);
     gf_cond_neg(s,negs);
 
     mask_t negz = ~negs ^ toggle_s ^ negx;
-    gf_copy(inv_el_m1,p->z);
+    gf_copy(inv_el_m1,&p->z);
     gf_cond_neg(inv_el_m1,negz);
-    gf_sub(inv_el_m1,inv_el_m1,t4);
+    gf_sub(inv_el_m1,inv_el_m1,&t4);
 }
 
-void ristretto255_point_encode( unsigned char ser[SER_BYTES], const point_t p ) {
-    gf s,ie1,ie2;
-    ristretto255_deisogenize(s,ie1,ie2,p,0,0,0);
-    gf_serialize(ser,s,1);
+void ristretto255_point_encode( unsigned char ser[SER_BYTES], const point_t *p ) {
+    gf_25519_t s,ie1,ie2;
+    ristretto255_deisogenize(&s,&ie1,&ie2,p,0,0,0);
+    gf_serialize(ser,&s,1);
 }
 
 ristretto_error_t ristretto255_point_decode (
-    point_t p,
+    point_t *p,
     const unsigned char ser[SER_BYTES],
     ristretto_bool_t allow_identity
 ) {
-    gf s, s2, num, tmp;
-    gf_s *tmp2=s2, *ynum=p->z, *isr=p->x, *den=p->t;
+    gf_25519_t s, s2, num, tmp;
+    gf_25519_t *tmp2=&s2, *ynum=&p->z, *isr=&p->x, *den=&p->t;
 
-    mask_t succ = gf_deserialize(s, ser, 1, 0);
-    succ &= bool_to_mask(allow_identity) | ~gf_eq(s, ZERO);
-    succ &= ~gf_lobit(s);
+    mask_t succ = gf_deserialize(&s, ser, 1, 0);
+    succ &= bool_to_mask(allow_identity) | ~gf_eq(&s, &ZERO);
+    succ &= ~gf_lobit(&s);
 
-    gf_sqr(s2,s);                  /* s^2 = -as^2 */
-    gf_sub(s2,ZERO,s2);            /* -as^2 */
-    gf_sub(den,ONE,s2);            /* 1+as^2 */
-    gf_add(ynum,ONE,s2);           /* 1-as^2 */
-    gf_mulw(num,s2,-4*TWISTED_D);
-    gf_sqr(tmp,den);               /* tmp = den^2 */
-    gf_add(num,tmp,num);           /* num = den^2 - 4*d*s^2 */
-    gf_mul(tmp2,num,tmp);          /* tmp2 = num*den^2 */
-    succ &= gf_isr(isr,tmp2);      /* isr = 1/sqrt(num*den^2) */
-    gf_mul(tmp,isr,den);           /* isr*den */
-    gf_mul(p->y,tmp,ynum);         /* isr*den*(1-as^2) */
-    gf_mul(tmp2,tmp,s);            /* s*isr*den */
-    gf_add(tmp2,tmp2,tmp2);        /* 2*s*isr*den */
-    gf_mul(tmp,tmp2,isr);          /* 2*s*isr^2*den */
-    gf_mul(p->x,tmp,num);          /* 2*s*isr^2*den*num */
-    gf_mul(tmp,tmp2,RISTRETTO255_FACTOR); /* 2*s*isr*den*magic */
-    gf_cond_neg(p->x,gf_lobit(tmp)); /* flip x */
+    gf_sqr(&s2,&s);                  /* s^2 = -as^2 */
+    gf_sub(&s2,&ZERO,&s2);           /* -as^2 */
+    gf_sub(den,&ONE,&s2);            /* 1+as^2 */
+    gf_add(ynum,&ONE,&s2);           /* 1-as^2 */
+    gf_mulw(&num,&s2,-4*TWISTED_D);
+    gf_sqr(&tmp,den);                /* tmp = den^2 */
+    gf_add(&num,&tmp,&num);          /* num = den^2 - 4*d*s^2 */
+    gf_mul(tmp2,&num,&tmp);          /* tmp2 = num*den^2 */
+    succ &= gf_isr(isr,tmp2);        /* isr = 1/sqrt(num*den^2) */
+    gf_mul(&tmp,isr,den);            /* isr*den */
+    gf_mul(&p->y,&tmp,ynum);         /* isr*den*(1-as^2) */
+    gf_mul(tmp2,&tmp,&s);            /* s*isr*den */
+    gf_add(tmp2,tmp2,tmp2);          /* 2*s*isr*den */
+    gf_mul(&tmp,tmp2,isr);           /* 2*s*isr^2*den */
+    gf_mul(&p->x,&tmp,&num);         /* 2*s*isr^2*den*num */
+    gf_mul(&tmp,tmp2,&RISTRETTO255_FACTOR); /* 2*s*isr*den*magic */
+    gf_cond_neg(&p->x,gf_lobit(&tmp)); /* flip x */
 
     /* Additionally check y != 0 and x*y*isomagic nonegative */
-    succ &= ~gf_eq(p->y,ZERO);
-    gf_mul(tmp,p->x,p->y);
-    gf_mul(tmp2,tmp,RISTRETTO255_FACTOR);
+    succ &= ~gf_eq(&p->y,&ZERO);
+    gf_mul(&tmp,&p->x,&p->y);
+    gf_mul(tmp2,&tmp,&RISTRETTO255_FACTOR);
     succ &= ~gf_lobit(tmp2);
 
-    gf_copy(tmp,p->x);
-    gf_mul_i(p->x,tmp);
+    gf_copy(&tmp,&p->x);
+    gf_mul_i(&p->x,&tmp);
 
     /* Fill in z and t */
-    gf_copy(p->z,ONE);
-    gf_mul(p->t,p->x,p->y);
+    gf_copy(&p->z,&ONE);
+    gf_mul(&p->t,&p->x,&p->y);
 
     assert(ristretto255_point_valid(p) | ~succ);
     return ristretto_succeed_if(mask_to_bool(succ));
 }
 
 void ristretto255_point_sub (
-    point_t p,
-    const point_t q,
-    const point_t r
+    point_t *p,
+    const point_t *q,
+    const point_t *r
 ) {
-    gf a, b, c, d;
-    gf_sub_nr ( b, q->y, q->x ); /* 3+e */
-    gf_sub_nr ( d, r->y, r->x ); /* 3+e */
-    gf_add_nr ( c, r->y, r->x ); /* 2+e */
-    gf_mul ( a, c, b );
-    gf_add_nr ( b, q->y, q->x ); /* 2+e */
-    gf_mul ( p->y, d, b );
-    gf_mul ( b, r->t, q->t );
-    gf_mulw ( p->x, b, 2*EFF_D );
-    gf_add_nr ( b, a, p->y );    /* 2+e */
-    gf_sub_nr ( c, p->y, a );    /* 3+e */
-    gf_mul ( a, q->z, r->z );
-    gf_add_nr ( a, a, a );       /* 2+e */
-    if (GF_HEADROOM <= 3) gf_weak_reduce(a); /* or 1+e */
-#if NEG_D
-    gf_sub_nr ( p->y, a, p->x ); /* 4+e or 3+e */
-    gf_add_nr ( a, a, p->x );    /* 3+e or 2+e */
-#else
-    gf_add_nr ( p->y, a, p->x ); /* 3+e or 2+e */
-    gf_sub_nr ( a, a, p->x );    /* 4+e or 3+e */
-#endif
-    gf_mul ( p->z, a, p->y );
-    gf_mul ( p->x, p->y, c );
-    gf_mul ( p->y, a, b );
-    gf_mul ( p->t, b, c );
+    gf_25519_t a, b, c, d;
+    gf_sub_nr ( &b, &q->y, &q->x ); /* 3+e */
+    gf_sub_nr ( &d, &r->y, &r->x ); /* 3+e */
+    gf_add_nr ( &c, &r->y, &r->x ); /* 2+e */
+    gf_mul ( &a, &c, &b );
+    gf_add_nr ( &b, &q->y, &q->x ); /* 2+e */
+    gf_mul ( &p->y, &d, &b );
+    gf_mul ( &b, &r->t, &q->t );
+    gf_mulw ( &p->x, &b, 2*TWISTED_D );
+    gf_add_nr ( &b, &a, &p->y );    /* 2+e */
+    gf_sub_nr ( &c, &p->y, &a );    /* 3+e */
+    gf_mul ( &a, &q->z, &r->z );
+    gf_add_nr ( &a, &a, &a );       /* 2+e */
+    if (GF_HEADROOM <= 3) gf_weak_reduce(&a); /* or 1+e */
+    gf_add_nr ( &p->y, &a, &p->x ); /* 3+e or 2+e */
+    gf_sub_nr ( &a, &a, &p->x );    /* 4+e or 3+e */
+    gf_mul ( &p->z, &a, &p->y );
+    gf_mul ( &p->x, &p->y, &c );
+    gf_mul ( &p->y, &a, &b );
+    gf_mul ( &p->t, &b, &c );
 }
 
 void ristretto255_point_add (
-    point_t p,
-    const point_t q,
-    const point_t r
+    point_t *p,
+    const point_t *q,
+    const point_t *r
 ) {
-    gf a, b, c, d;
-    gf_sub_nr ( b, q->y, q->x ); /* 3+e */
-    gf_sub_nr ( c, r->y, r->x ); /* 3+e */
-    gf_add_nr ( d, r->y, r->x ); /* 2+e */
-    gf_mul ( a, c, b );
-    gf_add_nr ( b, q->y, q->x ); /* 2+e */
-    gf_mul ( p->y, d, b );
-    gf_mul ( b, r->t, q->t );
-    gf_mulw ( p->x, b, 2*EFF_D );
-    gf_add_nr ( b, a, p->y );    /* 2+e */
-    gf_sub_nr ( c, p->y, a );    /* 3+e */
-    gf_mul ( a, q->z, r->z );
-    gf_add_nr ( a, a, a );       /* 2+e */
-    if (GF_HEADROOM <= 3) gf_weak_reduce(a); /* or 1+e */
-#if NEG_D
-    gf_add_nr ( p->y, a, p->x ); /* 3+e or 2+e */
-    gf_sub_nr ( a, a, p->x );    /* 4+e or 3+e */
-#else
-    gf_sub_nr ( p->y, a, p->x ); /* 4+e or 3+e */
-    gf_add_nr ( a, a, p->x );    /* 3+e or 2+e */
-#endif
-    gf_mul ( p->z, a, p->y );
-    gf_mul ( p->x, p->y, c );
-    gf_mul ( p->y, a, b );
-    gf_mul ( p->t, b, c );
+    gf_25519_t a, b, c, d;
+    gf_sub_nr ( &b, &q->y, &q->x ); /* 3+e */
+    gf_sub_nr ( &c, &r->y, &r->x ); /* 3+e */
+    gf_add_nr ( &d, &r->y, &r->x ); /* 2+e */
+    gf_mul ( &a, &c, &b );
+    gf_add_nr ( &b, &q->y, &q->x ); /* 2+e */
+    gf_mul ( &p->y, &d, &b );
+    gf_mul ( &b, &r->t, &q->t );
+    gf_mulw ( &p->x, &b, 2*TWISTED_D );
+    gf_add_nr ( &b, &a, &p->y );    /* 2+e */
+    gf_sub_nr ( &c, &p->y, &a );    /* 3+e */
+    gf_mul ( &a, &q->z, &r->z );
+    gf_add_nr ( &a, &a, &a );       /* 2+e */
+    if (GF_HEADROOM <= 3) gf_weak_reduce(&a); /* or 1+e */
+    gf_sub_nr ( &p->y, &a, &p->x ); /* 4+e or 3+e */
+    gf_add_nr ( &a, &a, &p->x );    /* 3+e or 2+e */
+    gf_mul ( &p->z, &a, &p->y );
+    gf_mul ( &p->x, &p->y, &c );
+    gf_mul ( &p->y, &a, &b );
+    gf_mul ( &p->t, &b, &c );
 }
 
 static RISTRETTO_NOINLINE void
 point_double_internal (
-    point_t p,
-    const point_t q,
+    point_t *p,
+    const point_t *q,
     int before_double
 ) {
-    gf a, b, c, d;
-    gf_sqr ( c, q->x );
-    gf_sqr ( a, q->y );
-    gf_add_nr ( d, c, a );             /* 2+e */
-    gf_add_nr ( p->t, q->y, q->x );    /* 2+e */
-    gf_sqr ( b, p->t );
-    gf_subx_nr ( b, b, d, 3 );         /* 4+e */
-    gf_sub_nr ( p->t, a, c );          /* 3+e */
-    gf_sqr ( p->x, q->z );
-    gf_add_nr ( p->z, p->x, p->x );    /* 2+e */
-    gf_subx_nr ( a, p->z, p->t, 4 );   /* 6+e */
-    if (GF_HEADROOM == 5) gf_weak_reduce(a); /* or 1+e */
-    gf_mul ( p->x, a, b );
-    gf_mul ( p->z, p->t, a );
-    gf_mul ( p->y, p->t, d );
-    if (!before_double) gf_mul ( p->t, b, d );
+    gf_25519_t a, b, c, d;
+    gf_sqr ( &c, &q->x );
+    gf_sqr ( &a, &q->y );
+    gf_add_nr ( &d, &c, &a );             /* 2+e */
+    gf_add_nr ( &p->t, &q->y, &q->x );    /* 2+e */
+    gf_sqr ( &b, &p->t );
+    gf_subx_nr ( &b, &b, &d, 3 );         /* 4+e */
+    gf_sub_nr ( &p->t, &a, &c );          /* 3+e */
+    gf_sqr ( &p->x, &q->z );
+    gf_add_nr ( &p->z, &p->x, &p->x );    /* 2+e */
+    gf_subx_nr ( &a, &p->z, &p->t, 4 );   /* 6+e */
+    if (GF_HEADROOM == 5) gf_weak_reduce(&a); /* or 1+e */
+    gf_mul ( &p->x, &a, &b );
+    gf_mul ( &p->z, &p->t, &a );
+    gf_mul ( &p->y, &p->t, &d );
+    if (!before_double) gf_mul ( &p->t, &b, &d );
 }
 
-void ristretto255_point_double(point_t p, const point_t q) {
+void ristretto255_point_double(point_t *p, const point_t *q) {
     point_double_internal(p,q,0);
 }
 
 void ristretto255_point_negate (
-   point_t nega,
-   const point_t a
+   point_t *nega,
+   const point_t *a
 ) {
-    gf_sub(nega->x, ZERO, a->x);
-    gf_copy(nega->y, a->y);
-    gf_copy(nega->z, a->z);
-    gf_sub(nega->t, ZERO, a->t);
+    gf_sub(&nega->x, &ZERO, &a->x);
+    gf_copy(&nega->y, &a->y);
+    gf_copy(&nega->z, &a->z);
+    gf_sub(&nega->t, &ZERO, &a->t);
 }
 
 /* Operations on [p]niels */
 static RISTRETTO_INLINE void
 cond_neg_niels (
-    niels_t n,
+    niels_t *n,
     mask_t neg
 ) {
-    gf_cond_swap(n->a, n->b, neg);
-    gf_cond_neg(n->c, neg);
+    gf_cond_swap(&n->a, &n->b, neg);
+    gf_cond_neg(&n->c, neg);
 }
 
 static RISTRETTO_NOINLINE void pt_to_pniels (
-    pniels_t b,
-    const point_t a
+    pniels_t *b,
+    const point_t *a
 ) {
-    gf_sub ( b->n->a, a->y, a->x );
-    gf_add ( b->n->b, a->x, a->y );
-    gf_mulw ( b->n->c, a->t, 2*TWISTED_D );
-    gf_add ( b->z, a->z, a->z );
+    gf_sub ( &b->n.a, &a->y, &a->x );
+    gf_add ( &b->n.b, &a->x, &a->y );
+    gf_mulw ( &b->n.c, &a->t, 2*TWISTED_D );
+    gf_add ( &b->z, &a->z, &a->z );
 }
 
 static RISTRETTO_NOINLINE void pniels_to_pt (
-    point_t e,
-    const pniels_t d
+    point_t *e,
+    const pniels_t *d
 ) {
-    gf eu;
-    gf_add ( eu, d->n->b, d->n->a );
-    gf_sub ( e->y, d->n->b, d->n->a );
-    gf_mul ( e->t, e->y, eu);
-    gf_mul ( e->x, d->z, e->y );
-    gf_mul ( e->y, d->z, eu );
-    gf_sqr ( e->z, d->z );
+    gf_25519_t eu;
+    gf_add ( &eu, &d->n.b, &d->n.a );
+    gf_sub ( &e->y, &d->n.b, &d->n.a );
+    gf_mul ( &e->t, &e->y, &eu);
+    gf_mul ( &e->x, &d->z, &e->y );
+    gf_mul ( &e->y, &d->z, &eu );
+    gf_sqr ( &e->z, &d->z );
 }
 
 static RISTRETTO_NOINLINE void
 niels_to_pt (
-    point_t e,
-    const niels_t n
+    point_t *e,
+    const niels_t *n
 ) {
-    gf_add ( e->y, n->b, n->a );
-    gf_sub ( e->x, n->b, n->a );
-    gf_mul ( e->t, e->y, e->x );
-    gf_copy ( e->z, ONE );
+    gf_add ( &e->y, &n->b, &n->a );
+    gf_sub ( &e->x, &n->b, &n->a );
+    gf_mul ( &e->t, &e->y, &e->x );
+    gf_copy ( &e->z, &ONE );
 }
 
 static RISTRETTO_NOINLINE void
 add_niels_to_pt (
-    point_t d,
-    const niels_t e,
+    point_t *d,
+    const niels_t *e,
     int before_double
 ) {
-    gf a, b, c;
-    gf_sub_nr ( b, d->y, d->x ); /* 3+e */
-    gf_mul ( a, e->a, b );
-    gf_add_nr ( b, d->x, d->y ); /* 2+e */
-    gf_mul ( d->y, e->b, b );
-    gf_mul ( d->x, e->c, d->t );
-    gf_add_nr ( c, a, d->y );    /* 2+e */
-    gf_sub_nr ( b, d->y, a );    /* 3+e */
-    gf_sub_nr ( d->y, d->z, d->x ); /* 3+e */
-    gf_add_nr ( a, d->x, d->z ); /* 2+e */
-    gf_mul ( d->z, a, d->y );
-    gf_mul ( d->x, d->y, b );
-    gf_mul ( d->y, a, c );
-    if (!before_double) gf_mul ( d->t, b, c );
+    gf_25519_t a, b, c;
+    gf_sub_nr ( &b, &d->y, &d->x ); /* 3+e */
+    gf_mul ( &a, &e->a, &b );
+    gf_add_nr ( &b, &d->x, &d->y ); /* 2+e */
+    gf_mul ( &d->y, &e->b, &b );
+    gf_mul ( &d->x, &e->c, &d->t );
+    gf_add_nr ( &c, &a, &d->y );    /* 2+e */
+    gf_sub_nr ( &b, &d->y, &a );    /* 3+e */
+    gf_sub_nr ( &d->y, &d->z, &d->x ); /* 3+e */
+    gf_add_nr ( &a, &d->x, &d->z ); /* 2+e */
+    gf_mul ( &d->z, &a, &d->y );
+    gf_mul ( &d->x, &d->y, &b );
+    gf_mul ( &d->y, &a, &c );
+    if (!before_double) gf_mul ( &d->t, &b, &c );
 }
 
 static RISTRETTO_NOINLINE void
 sub_niels_from_pt (
-    point_t d,
-    const niels_t e,
+    point_t *d,
+    const niels_t *e,
     int before_double
 ) {
-    gf a, b, c;
-    gf_sub_nr ( b, d->y, d->x ); /* 3+e */
-    gf_mul ( a, e->b, b );
-    gf_add_nr ( b, d->x, d->y ); /* 2+e */
-    gf_mul ( d->y, e->a, b );
-    gf_mul ( d->x, e->c, d->t );
-    gf_add_nr ( c, a, d->y );    /* 2+e */
-    gf_sub_nr ( b, d->y, a );    /* 3+e */
-    gf_add_nr ( d->y, d->z, d->x ); /* 2+e */
-    gf_sub_nr ( a, d->z, d->x ); /* 3+e */
-    gf_mul ( d->z, a, d->y );
-    gf_mul ( d->x, d->y, b );
-    gf_mul ( d->y, a, c );
-    if (!before_double) gf_mul ( d->t, b, c );
+    gf_25519_t a, b, c;
+    gf_sub_nr ( &b, &d->y, &d->x ); /* 3+e */
+    gf_mul ( &a, &e->b, &b );
+    gf_add_nr ( &b, &d->x, &d->y ); /* 2+e */
+    gf_mul ( &d->y, &e->a, &b );
+    gf_mul ( &d->x, &e->c, &d->t );
+    gf_add_nr ( &c, &a, &d->y );    /* 2+e */
+    gf_sub_nr ( &b, &d->y, &a );    /* 3+e */
+    gf_add_nr ( &d->y, &d->z, &d->x ); /* 2+e */
+    gf_sub_nr ( &a, &d->z, &d->x ); /* 3+e */
+    gf_mul ( &d->z, &a, &d->y );
+    gf_mul ( &d->x, &d->y, &b );
+    gf_mul ( &d->y, &a, &c );
+    if (!before_double) gf_mul ( &d->t, &b, &c );
 }
 
 static void
 add_pniels_to_pt (
-    point_t p,
-    const pniels_t pn,
+    point_t *p,
+    const pniels_t *pn,
     int before_double
 ) {
-    gf L0;
-    gf_mul ( L0, p->z, pn->z );
-    gf_copy ( p->z, L0 );
-    add_niels_to_pt( p, pn->n, before_double );
+    gf_25519_t L0;
+    gf_mul ( &L0, &p->z, &pn->z );
+    gf_copy ( &p->z, &L0 );
+    add_niels_to_pt( p, &pn->n, before_double );
 }
 
 static void
 sub_pniels_from_pt (
-    point_t p,
-    const pniels_t pn,
+    point_t *p,
+    const pniels_t *pn,
     int before_double
 ) {
-    gf L0;
-    gf_mul ( L0, p->z, pn->z );
-    gf_copy ( p->z, L0 );
-    sub_niels_from_pt( p, pn->n, before_double );
+    gf_25519_t L0;
+    gf_mul ( &L0, &p->z, &pn->z );
+    gf_copy ( &p->z, &L0 );
+    sub_niels_from_pt( p, &pn->n, before_double );
 }
 
 static RISTRETTO_NOINLINE void
 prepare_fixed_window(
     pniels_t *multiples,
-    const point_t b,
+    const point_t *b,
     int ntable
 ) {
     point_t tmp;
     pniels_t pn;
     int i;
 
-    point_double_internal(tmp, b, 0);
-    pt_to_pniels(pn, tmp);
-    pt_to_pniels(multiples[0], b);
-    ristretto255_point_copy(tmp, b);
+    point_double_internal(&tmp, b, 0);
+    pt_to_pniels(&pn, &tmp);
+    pt_to_pniels(&multiples[0], b);
+    ristretto255_point_copy(&tmp, b);
     for (i=1; i<ntable; i++) {
-        add_pniels_to_pt(tmp, pn, 0);
-        pt_to_pniels(multiples[i], tmp);
+        add_pniels_to_pt(&tmp, &pn, 0);
+        pt_to_pniels(&multiples[i], &tmp);
     }
 
-    ristretto_bzero(pn,sizeof(pn));
-    ristretto_bzero(tmp,sizeof(tmp));
+    ristretto_bzero(&pn,sizeof(pn));
+    ristretto_bzero(&tmp,sizeof(tmp));
 }
 
 void ristretto255_point_scalarmul (
-    point_t a,
-    const point_t b,
-    const scalar_t scalar
+    point_t *a,
+    const point_t *b,
+    const scalar_t *scalar
 ) {
-
     const int WINDOW = RISTRETTO_WINDOW_BITS,
         WINDOW_MASK = (1<<WINDOW)-1,
         WINDOW_T_MASK = WINDOW_MASK >> 1,
         NTABLE = 1<<(WINDOW-1);
 
     scalar_t scalar1x;
-    ristretto255_scalar_add(scalar1x, scalar, point_scalarmul_adjustment);
-    ristretto255_scalar_halve(scalar1x,scalar1x);
+    ristretto255_scalar_add(&scalar1x, scalar, &point_scalarmul_adjustment);
+    ristretto255_scalar_halve(&scalar1x,&scalar1x);
 
     /* Set up a precomputed table with odd multiples of b. */
     pniels_t pn, multiples[1<<((int)(RISTRETTO_WINDOW_BITS)-1)];  // == NTABLE (MSVC compatibility issue)
@@ -471,19 +452,19 @@ void ristretto255_point_scalarmul (
 
     for (; i>=0; i-=WINDOW) {
         /* Fetch another block of bits */
-        word_t bits = scalar1x->limb[i/WBITS] >> (i%WBITS);
+        word_t bits = scalar1x.limb[i/WBITS] >> (i%WBITS);
         if (i%WBITS >= WBITS-WINDOW && i/WBITS<SCALAR_LIMBS-1) {
-            bits ^= scalar1x->limb[i/WBITS+1] << (WBITS - (i%WBITS));
+            bits ^= scalar1x.limb[i/WBITS+1] << (WBITS - (i%WBITS));
         }
         bits &= WINDOW_MASK;
         mask_t inv = (bits>>(WINDOW-1))-1;
         bits ^= inv;
 
         /* Add in from table.  Compute t only on last iteration. */
-        constant_time_lookup(pn, multiples, sizeof(pn), NTABLE, bits & WINDOW_T_MASK);
-        cond_neg_niels(pn->n, inv);
+        constant_time_lookup(&pn, multiples, sizeof(pn), NTABLE, bits & WINDOW_T_MASK);
+        cond_neg_niels(&pn.n, inv);
         if (first) {
-            pniels_to_pt(tmp, pn);
+            pniels_to_pt(&tmp, &pn);
             first = 0;
         } else {
            /* Using Hisil et al's lookahead method instead of extensible here
@@ -491,27 +472,27 @@ void ristretto255_point_scalarmul (
             * the last one.
             */
             for (j=0; j<WINDOW-1; j++)
-                point_double_internal(tmp, tmp, -1);
-            point_double_internal(tmp, tmp, 0);
-            add_pniels_to_pt(tmp, pn, i ? -1 : 0);
+                point_double_internal(&tmp, &tmp, -1);
+            point_double_internal(&tmp, &tmp, 0);
+            add_pniels_to_pt(&tmp, &pn, i ? -1 : 0);
         }
     }
 
     /* Write out the answer */
-    ristretto255_point_copy(a,tmp);
+    ristretto255_point_copy(a,&tmp);
 
-    ristretto_bzero(scalar1x,sizeof(scalar1x));
-    ristretto_bzero(pn,sizeof(pn));
-    ristretto_bzero(multiples,sizeof(multiples));
-    ristretto_bzero(tmp,sizeof(tmp));
+    ristretto_bzero(&scalar1x,sizeof(scalar1x));
+    ristretto_bzero(&pn,sizeof(pn));
+    ristretto_bzero(&multiples,sizeof(multiples));
+    ristretto_bzero(&tmp,sizeof(tmp));
 }
 
 void ristretto255_point_double_scalarmul (
-    point_t a,
-    const point_t b,
-    const scalar_t scalarb,
-    const point_t c,
-    const scalar_t scalarc
+    point_t *a,
+    const point_t *b,
+    const scalar_t *scalarb,
+    const point_t *c,
+    const scalar_t *scalarc
 ) {
 
     const int WINDOW = RISTRETTO_WINDOW_BITS,
@@ -520,10 +501,10 @@ void ristretto255_point_double_scalarmul (
         NTABLE = 1<<(WINDOW-1);
 
     scalar_t scalar1x, scalar2x;
-    ristretto255_scalar_add(scalar1x, scalarb, point_scalarmul_adjustment);
-    ristretto255_scalar_halve(scalar1x,scalar1x);
-    ristretto255_scalar_add(scalar2x, scalarc, point_scalarmul_adjustment);
-    ristretto255_scalar_halve(scalar2x,scalar2x);
+    ristretto255_scalar_add(&scalar1x, scalarb, &point_scalarmul_adjustment);
+    ristretto255_scalar_halve(&scalar1x,&scalar1x);
+    ristretto255_scalar_add(&scalar2x, scalarc, &point_scalarmul_adjustment);
+    ristretto255_scalar_halve(&scalar2x,&scalar2x);
 
     /* Set up a precomputed table with odd multiples of b. */
     pniels_t pn, multiples1[1<<((int)(RISTRETTO_WINDOW_BITS)-1)], multiples2[1<<((int)(RISTRETTO_WINDOW_BITS)-1)];
@@ -538,11 +519,11 @@ void ristretto255_point_double_scalarmul (
 
     for (; i>=0; i-=WINDOW) {
         /* Fetch another block of bits */
-        word_t bits1 = scalar1x->limb[i/WBITS] >> (i%WBITS),
-                     bits2 = scalar2x->limb[i/WBITS] >> (i%WBITS);
+        word_t bits1 = scalar1x.limb[i/WBITS] >> (i%WBITS),
+                     bits2 = scalar2x.limb[i/WBITS] >> (i%WBITS);
         if (i%WBITS >= WBITS-WINDOW && i/WBITS<SCALAR_LIMBS-1) {
-            bits1 ^= scalar1x->limb[i/WBITS+1] << (WBITS - (i%WBITS));
-            bits2 ^= scalar2x->limb[i/WBITS+1] << (WBITS - (i%WBITS));
+            bits1 ^= scalar1x.limb[i/WBITS+1] << (WBITS - (i%WBITS));
+            bits2 ^= scalar2x.limb[i/WBITS+1] << (WBITS - (i%WBITS));
         }
         bits1 &= WINDOW_MASK;
         bits2 &= WINDOW_MASK;
@@ -552,10 +533,10 @@ void ristretto255_point_double_scalarmul (
         bits2 ^= inv2;
 
         /* Add in from table.  Compute t only on last iteration. */
-        constant_time_lookup(pn, multiples1, sizeof(pn), NTABLE, bits1 & WINDOW_T_MASK);
-        cond_neg_niels(pn->n, inv1);
+        constant_time_lookup(&pn, multiples1, sizeof(pn), NTABLE, bits1 & WINDOW_T_MASK);
+        cond_neg_niels(&pn.n, inv1);
         if (first) {
-            pniels_to_pt(tmp, pn);
+            pniels_to_pt(&tmp, &pn);
             first = 0;
         } else {
            /* Using Hisil et al's lookahead method instead of extensible here
@@ -563,33 +544,33 @@ void ristretto255_point_double_scalarmul (
             * the last one.
             */
             for (j=0; j<WINDOW-1; j++)
-                point_double_internal(tmp, tmp, -1);
-            point_double_internal(tmp, tmp, 0);
-            add_pniels_to_pt(tmp, pn, 0);
+                point_double_internal(&tmp, &tmp, -1);
+            point_double_internal(&tmp, &tmp, 0);
+            add_pniels_to_pt(&tmp, &pn, 0);
         }
-        constant_time_lookup(pn, multiples2, sizeof(pn), NTABLE, bits2 & WINDOW_T_MASK);
-        cond_neg_niels(pn->n, inv2);
-        add_pniels_to_pt(tmp, pn, i?-1:0);
+        constant_time_lookup(&pn, multiples2, sizeof(pn), NTABLE, bits2 & WINDOW_T_MASK);
+        cond_neg_niels(&pn.n, inv2);
+        add_pniels_to_pt(&tmp, &pn, i?-1:0);
     }
 
     /* Write out the answer */
-    ristretto255_point_copy(a,tmp);
+    ristretto255_point_copy(a,&tmp);
 
 
-    ristretto_bzero(scalar1x,sizeof(scalar1x));
-    ristretto_bzero(scalar2x,sizeof(scalar2x));
-    ristretto_bzero(pn,sizeof(pn));
-    ristretto_bzero(multiples1,sizeof(multiples1));
-    ristretto_bzero(multiples2,sizeof(multiples2));
-    ristretto_bzero(tmp,sizeof(tmp));
+    ristretto_bzero(&scalar1x,sizeof(scalar1x));
+    ristretto_bzero(&scalar2x,sizeof(scalar2x));
+    ristretto_bzero(&pn,sizeof(pn));
+    ristretto_bzero(&multiples1,sizeof(multiples1));
+    ristretto_bzero(&multiples2,sizeof(multiples2));
+    ristretto_bzero(&tmp,sizeof(tmp));
 }
 
 void ristretto255_point_dual_scalarmul (
-    point_t a1,
-    point_t a2,
-    const point_t b,
-    const scalar_t scalar1,
-    const scalar_t scalar2
+    point_t *a1,
+    point_t *a2,
+    const point_t *b,
+    const scalar_t *scalar1,
+    const scalar_t *scalar2
 ) {
 
     const int WINDOW = RISTRETTO_WINDOW_BITS,
@@ -599,10 +580,10 @@ void ristretto255_point_dual_scalarmul (
 
 
     scalar_t scalar1x, scalar2x;
-    ristretto255_scalar_add(scalar1x, scalar1, point_scalarmul_adjustment);
-    ristretto255_scalar_halve(scalar1x,scalar1x);
-    ristretto255_scalar_add(scalar2x, scalar2, point_scalarmul_adjustment);
-    ristretto255_scalar_halve(scalar2x,scalar2x);
+    ristretto255_scalar_add(&scalar1x, scalar1, &point_scalarmul_adjustment);
+    ristretto255_scalar_halve(&scalar1x,&scalar1x);
+    ristretto255_scalar_add(&scalar2x, scalar2, &point_scalarmul_adjustment);
+    ristretto255_scalar_halve(&scalar2x,&scalar2x);
 
     /* Set up a precomputed table with odd multiples of b. */
     point_t multiples1[1<<((int)(RISTRETTO_WINDOW_BITS)-1)], multiples2[1<<((int)(RISTRETTO_WINDOW_BITS)-1)], working, tmp;
@@ -610,29 +591,29 @@ void ristretto255_point_dual_scalarmul (
 
     pniels_t pn;
 
-    ristretto255_point_copy(working, b);
+    ristretto255_point_copy(&working, b);
 
     /* Initialize. */
     int i,j;
 
     for (i=0; i<NTABLE; i++) {
-        ristretto255_point_copy(multiples1[i], ristretto255_point_identity);
-        ristretto255_point_copy(multiples2[i], ristretto255_point_identity);
+        ristretto255_point_copy(&multiples1[i], &ristretto255_point_identity);
+        ristretto255_point_copy(&multiples2[i], &ristretto255_point_identity);
     }
 
     for (i=0; i<SCALAR_BITS; i+=WINDOW) {
         if (i) {
             for (j=0; j<WINDOW-1; j++)
-                point_double_internal(working, working, -1);
-            point_double_internal(working, working, 0);
+                point_double_internal(&working, &working, -1);
+            point_double_internal(&working, &working, 0);
         }
 
         /* Fetch another block of bits */
-        word_t bits1 = scalar1x->limb[i/WBITS] >> (i%WBITS),
-               bits2 = scalar2x->limb[i/WBITS] >> (i%WBITS);
+        word_t bits1 = scalar1x.limb[i/WBITS] >> (i%WBITS),
+               bits2 = scalar2x.limb[i/WBITS] >> (i%WBITS);
         if (i%WBITS >= WBITS-WINDOW && i/WBITS<SCALAR_LIMBS-1) {
-            bits1 ^= scalar1x->limb[i/WBITS+1] << (WBITS - (i%WBITS));
-            bits2 ^= scalar2x->limb[i/WBITS+1] << (WBITS - (i%WBITS));
+            bits1 ^= scalar1x.limb[i/WBITS+1] << (WBITS - (i%WBITS));
+            bits2 ^= scalar2x.limb[i/WBITS+1] << (WBITS - (i%WBITS));
         }
         bits1 &= WINDOW_MASK;
         bits2 &= WINDOW_MASK;
@@ -641,186 +622,186 @@ void ristretto255_point_dual_scalarmul (
         bits1 ^= inv1;
         bits2 ^= inv2;
 
-        pt_to_pniels(pn, working);
+        pt_to_pniels(&pn, &working);
 
-        constant_time_lookup(tmp, multiples1, sizeof(tmp), NTABLE, bits1 & WINDOW_T_MASK);
-        cond_neg_niels(pn->n, inv1);
+        constant_time_lookup(&tmp, &multiples1, sizeof(tmp), NTABLE, bits1 & WINDOW_T_MASK);
+        cond_neg_niels(&pn.n, inv1);
         /* add_pniels_to_pt(multiples1[bits1 & WINDOW_T_MASK], pn, 0); */
-        add_pniels_to_pt(tmp, pn, 0);
-        constant_time_insert(multiples1, tmp, sizeof(tmp), NTABLE, bits1 & WINDOW_T_MASK);
+        add_pniels_to_pt(&tmp, &pn, 0);
+        constant_time_insert(multiples1, &tmp, sizeof(tmp), NTABLE, bits1 & WINDOW_T_MASK);
 
 
-        constant_time_lookup(tmp, multiples2, sizeof(tmp), NTABLE, bits2 & WINDOW_T_MASK);
-        cond_neg_niels(pn->n, inv1^inv2);
+        constant_time_lookup(&tmp, multiples2, sizeof(tmp), NTABLE, bits2 & WINDOW_T_MASK);
+        cond_neg_niels(&pn.n, inv1^inv2);
         /* add_pniels_to_pt(multiples2[bits2 & WINDOW_T_MASK], pn, 0); */
-        add_pniels_to_pt(tmp, pn, 0);
-        constant_time_insert(multiples2, tmp, sizeof(tmp), NTABLE, bits2 & WINDOW_T_MASK);
+        add_pniels_to_pt(&tmp, &pn, 0);
+        constant_time_insert(&multiples2, &tmp, sizeof(tmp), NTABLE, bits2 & WINDOW_T_MASK);
     }
 
     if (NTABLE > 1) {
-        ristretto255_point_copy(working, multiples1[NTABLE-1]);
-        ristretto255_point_copy(tmp    , multiples2[NTABLE-1]);
+        ristretto255_point_copy(&working, &multiples1[NTABLE-1]);
+        ristretto255_point_copy(&tmp    , &multiples2[NTABLE-1]);
 
         for (i=NTABLE-1; i>1; i--) {
-            ristretto255_point_add(multiples1[i-1], multiples1[i-1], multiples1[i]);
-            ristretto255_point_add(multiples2[i-1], multiples2[i-1], multiples2[i]);
-            ristretto255_point_add(working, working, multiples1[i-1]);
-            ristretto255_point_add(tmp,     tmp,     multiples2[i-1]);
+            ristretto255_point_add(&multiples1[i-1], &multiples1[i-1], &multiples1[i]);
+            ristretto255_point_add(&multiples2[i-1], &multiples2[i-1], &multiples2[i]);
+            ristretto255_point_add(&working, &working, &multiples1[i-1]);
+            ristretto255_point_add(&tmp,     &tmp,     &multiples2[i-1]);
         }
 
-        ristretto255_point_add(multiples1[0], multiples1[0], multiples1[1]);
-        ristretto255_point_add(multiples2[0], multiples2[0], multiples2[1]);
-        point_double_internal(working, working, 0);
-        point_double_internal(tmp,         tmp, 0);
-        ristretto255_point_add(a1, working, multiples1[0]);
-        ristretto255_point_add(a2, tmp,     multiples2[0]);
+        ristretto255_point_add(&multiples1[0], &multiples1[0], &multiples1[1]);
+        ristretto255_point_add(&multiples2[0], &multiples2[0], &multiples2[1]);
+        point_double_internal(&working, &working, 0);
+        point_double_internal(&tmp,         &tmp, 0);
+        ristretto255_point_add(a1, &working, &multiples1[0]);
+        ristretto255_point_add(a2, &tmp,     &multiples2[0]);
     } else {
-        ristretto255_point_copy(a1, multiples1[0]);
-        ristretto255_point_copy(a2, multiples2[0]);
+        ristretto255_point_copy(a1, &multiples1[0]);
+        ristretto255_point_copy(a2, &multiples2[0]);
     }
 
-    ristretto_bzero(scalar1x,sizeof(scalar1x));
-    ristretto_bzero(scalar2x,sizeof(scalar2x));
-    ristretto_bzero(pn,sizeof(pn));
-    ristretto_bzero(multiples1,sizeof(multiples1));
-    ristretto_bzero(multiples2,sizeof(multiples2));
-    ristretto_bzero(tmp,sizeof(tmp));
-    ristretto_bzero(working,sizeof(working));
+    ristretto_bzero(&scalar1x,sizeof(scalar1x));
+    ristretto_bzero(&scalar2x,sizeof(scalar2x));
+    ristretto_bzero(&pn,sizeof(pn));
+    ristretto_bzero(&multiples1,sizeof(multiples1));
+    ristretto_bzero(&multiples2,sizeof(multiples2));
+    ristretto_bzero(&tmp,sizeof(tmp));
+    ristretto_bzero(&working,sizeof(working));
 }
 
-ristretto_bool_t ristretto255_point_eq ( const point_t p, const point_t q ) {
+ristretto_bool_t ristretto255_point_eq ( const point_t *p, const point_t *q ) {
     /* equality mod 2-torsion compares x/y */
-    gf a, b;
-    gf_mul ( a, p->y, q->x );
-    gf_mul ( b, q->y, p->x );
-    mask_t succ = gf_eq(a,b);
+    gf_25519_t a, b;
+    gf_mul ( &a, &p->y, &q->x );
+    gf_mul ( &b, &q->y, &p->x );
+    mask_t succ = gf_eq(&a,&b);
 
-    gf_mul ( a, p->y, q->y );
-    gf_mul ( b, q->x, p->x );
+    gf_mul ( &a, &p->y, &q->y );
+    gf_mul ( &b, &q->x, &p->x );
 
     /* Interesting note: the 4tor would normally be rotation.
      * But because of the *i twist, it's actually
      * (x,y) <-> (iy,ix)
      */
 
-    succ |= gf_eq(a,b);
+    succ |= gf_eq(&a,&b);
 
     return mask_to_bool(succ);
 }
 
 ristretto_bool_t ristretto255_point_valid (
-    const point_t p
+    const point_t *p
 ) {
-    gf a,b,c;
-    gf_mul(a,p->x,p->y);
-    gf_mul(b,p->z,p->t);
-    mask_t out = gf_eq(a,b);
-    gf_sqr(a,p->x);
-    gf_sqr(b,p->y);
-    gf_sub(a,b,a);
-    gf_sqr(b,p->t);
-    gf_mulw(c,b,TWISTED_D);
-    gf_sqr(b,p->z);
-    gf_add(b,b,c);
-    out &= gf_eq(a,b);
-    out &= ~gf_eq(p->z,ZERO);
+    gf_25519_t a,b,c;
+    gf_mul(&a,&p->x,&p->y);
+    gf_mul(&b,&p->z,&p->t);
+    mask_t out = gf_eq(&a,&b);
+    gf_sqr(&a,&p->x);
+    gf_sqr(&b,&p->y);
+    gf_sub(&a,&b,&a);
+    gf_sqr(&b,&p->t);
+    gf_mulw(&c,&b,TWISTED_D);
+    gf_sqr(&b,&p->z);
+    gf_add(&b,&b,&c);
+    out &= gf_eq(&a,&b);
+    out &= ~gf_eq(&p->z,&ZERO);
     return mask_to_bool(out);
 }
 
 void ristretto255_point_debugging_torque (
-    point_t q,
-    const point_t p
+    point_t *q,
+    const point_t *p
 ) {
-    gf tmp;
-    gf_mul(tmp,p->x,SQRT_MINUS_ONE);
-    gf_mul(q->x,p->y,SQRT_MINUS_ONE);
-    gf_copy(q->y,tmp);
-    gf_copy(q->z,p->z);
-    gf_sub(q->t,ZERO,p->t);
+    gf_25519_t tmp;
+    gf_mul(&tmp,&p->x,&SQRT_MINUS_ONE);
+    gf_mul(&q->x,&p->y,&SQRT_MINUS_ONE);
+    gf_copy(&q->y,&tmp);
+    gf_copy(&q->z,&p->z);
+    gf_sub(&q->t,&ZERO,&p->t);
 }
 
 void ristretto255_point_debugging_pscale (
-    point_t q,
-    const point_t p,
+    point_t *q,
+    const point_t *p,
     const uint8_t factor[SER_BYTES]
 ) {
-    gf gfac,tmp;
-    ignore_result(gf_deserialize(gfac,factor,0,0));
-    gf_cond_sel(gfac,gfac,ONE,gf_eq(gfac,ZERO));
-    gf_mul(tmp,p->x,gfac);
-    gf_copy(q->x,tmp);
-    gf_mul(tmp,p->y,gfac);
-    gf_copy(q->y,tmp);
-    gf_mul(tmp,p->z,gfac);
-    gf_copy(q->z,tmp);
-    gf_mul(tmp,p->t,gfac);
-    gf_copy(q->t,tmp);
+    gf_25519_t gfac,tmp;
+    ignore_result(gf_deserialize(&gfac,factor,0,0));
+    gf_cond_sel(&gfac,&gfac,&ONE,gf_eq(&gfac,&ZERO));
+    gf_mul(&tmp,&p->x,&gfac);
+    gf_copy(&q->x,&tmp);
+    gf_mul(&tmp,&p->y,&gfac);
+    gf_copy(&q->y,&tmp);
+    gf_mul(&tmp,&p->z,&gfac);
+    gf_copy(&q->z,&tmp);
+    gf_mul(&tmp,&p->t,&gfac);
+    gf_copy(&q->t,&tmp);
 }
 
 static void gf_batch_invert (
-    gf *__restrict__ out,
-    const gf *in,
+    gf_25519_t *__restrict__ out,
+    const gf_25519_t *in,
     unsigned int n
 ) {
-    gf t1;
+    gf_25519_t t1;
     assert(n>1);
 
-    gf_copy(out[1], in[0]);
+    gf_copy(&out[1], &in[0]);
     int i;
     for (i=1; i<(int) (n-1); i++) {
-        gf_mul(out[i+1], out[i], in[i]);
+        gf_mul(&out[i+1], &out[i], &in[i]);
     }
-    gf_mul(out[0], out[n-1], in[n-1]);
+    gf_mul(&out[0], &out[n-1], &in[n-1]);
 
-    gf_invert(out[0], out[0], 1);
+    gf_invert(&out[0], &out[0], 1);
 
     for (i=n-1; i>0; i--) {
-        gf_mul(t1, out[i], out[0]);
-        gf_copy(out[i], t1);
-        gf_mul(t1, out[0], in[i]);
-        gf_copy(out[0], t1);
+        gf_mul(&t1, &out[i], &out[0]);
+        gf_copy(&out[i], &t1);
+        gf_mul(&t1, &out[0], &in[i]);
+        gf_copy(&out[0], &t1);
     }
 }
 
 static void batch_normalize_niels (
     niels_t *table,
-    const gf *zs,
-    gf *__restrict__ zis,
+    const gf_25519_t *zs,
+    gf_25519_t *__restrict__ zis,
     int n
 ) {
     int i;
-    gf product;
+    gf_25519_t product;
     gf_batch_invert(zis, zs, n);
 
     for (i=0; i<n; i++) {
-        gf_mul(product, table[i]->a, zis[i]);
-        gf_strong_reduce(product);
-        gf_copy(table[i]->a, product);
+        gf_mul(&product, &table[i].a, &zis[i]);
+        gf_strong_reduce(&product);
+        gf_copy(&table[i].a, &product);
 
-        gf_mul(product, table[i]->b, zis[i]);
-        gf_strong_reduce(product);
-        gf_copy(table[i]->b, product);
+        gf_mul(&product, &table[i].b, &zis[i]);
+        gf_strong_reduce(&product);
+        gf_copy(&table[i].b, &product);
 
-        gf_mul(product, table[i]->c, zis[i]);
-        gf_strong_reduce(product);
-        gf_copy(table[i]->c, product);
+        gf_mul(&product, &table[i].c, &zis[i]);
+        gf_strong_reduce(&product);
+        gf_copy(&table[i].c, &product);
     }
 
-    ristretto_bzero(product,sizeof(product));
+    ristretto_bzero(&product,sizeof(product));
 }
 
 void ristretto255_precompute (
     precomputed_s *table,
-    const point_t base
+    const point_t *base
 ) {
     const unsigned int n = COMBS_N, t = COMBS_T, s = COMBS_S;
     assert(n*t*s >= SCALAR_BITS);
 
     point_t working, start, doubles[COMBS_T-1];
-    ristretto255_point_copy(working, base);
+    ristretto255_point_copy(&working, base);
     pniels_t pn_tmp;
 
-    gf zs[(unsigned int)(COMBS_N)<<(unsigned int)(COMBS_T-1)], zis[(unsigned int)(COMBS_N)<<(unsigned int)(COMBS_T-1)];
+    gf_25519_t zs[(unsigned int)(COMBS_N)<<(unsigned int)(COMBS_T-1)], zis[(unsigned int)(COMBS_N)<<(unsigned int)(COMBS_T-1)];
 
     unsigned int i,j,k;
 
@@ -829,16 +810,16 @@ void ristretto255_precompute (
 
         /* Doubling phase */
         for (j=0; j<t; j++) {
-            if (j) ristretto255_point_add(start, start, working);
-            else ristretto255_point_copy(start, working);
+            if (j) ristretto255_point_add(&start, &start, &working);
+            else ristretto255_point_copy(&start, &working);
 
             if (j==t-1 && i==n-1) break;
 
-            point_double_internal(working, working,0);
-            if (j<t-1) ristretto255_point_copy(doubles[j], working);
+            point_double_internal(&working, &working,0);
+            if (j<t-1) ristretto255_point_copy(&doubles[j], &working);
 
             for (k=0; k<s-1; k++)
-                point_double_internal(working, working, k<s-2);
+                point_double_internal(&working, &working, k<s-2);
         }
 
         /* Gray-code phase */
@@ -846,9 +827,9 @@ void ristretto255_precompute (
             int gray = j ^ (j>>1);
             int idx = (((i+1)<<(t-1))-1) ^ gray;
 
-            pt_to_pniels(pn_tmp, start);
-            memcpy(table->table[idx], pn_tmp->n, sizeof(pn_tmp->n));
-            gf_copy(zs[idx], pn_tmp->z);
+            pt_to_pniels(&pn_tmp, &start);
+            memcpy(&table->table[idx], &pn_tmp.n, sizeof(pn_tmp.n));
+            gf_copy(&zs[idx], &pn_tmp.z);
 
             if (j >= (1u<<(t-1)) - 1) break;
             int delta = (j+1) ^ ((j+1)>>1) ^ gray;
@@ -857,45 +838,45 @@ void ristretto255_precompute (
                 delta >>=1;
 
             if (gray & (1<<k)) {
-                ristretto255_point_add(start, start, doubles[k]);
+                ristretto255_point_add(&start, &start, &doubles[k]);
             } else {
-                ristretto255_point_sub(start, start, doubles[k]);
+                ristretto255_point_sub(&start, &start, &doubles[k]);
             }
         }
     }
 
-    batch_normalize_niels(table->table,(const gf *)zs,zis,n<<(t-1));
+    batch_normalize_niels(table->table,zs,zis,n<<(t-1));
 
-    ristretto_bzero(zs,sizeof(zs));
-    ristretto_bzero(zis,sizeof(zis));
-    ristretto_bzero(pn_tmp,sizeof(pn_tmp));
-    ristretto_bzero(working,sizeof(working));
-    ristretto_bzero(start,sizeof(start));
-    ristretto_bzero(doubles,sizeof(doubles));
+    ristretto_bzero(&zs,sizeof(zs));
+    ristretto_bzero(&zis,sizeof(zis));
+    ristretto_bzero(&pn_tmp,sizeof(pn_tmp));
+    ristretto_bzero(&working,sizeof(working));
+    ristretto_bzero(&start,sizeof(start));
+    ristretto_bzero(&doubles,sizeof(doubles));
 }
 
 static RISTRETTO_INLINE void
 constant_time_lookup_niels (
-    niels_s *__restrict__ ni,
+    niels_t *__restrict__ ni,
     const niels_t *table,
     int nelts,
     int idx
 ) {
-    constant_time_lookup(ni, table, sizeof(niels_s), nelts, idx);
+    constant_time_lookup(ni, table, sizeof(niels_t), nelts, idx);
 }
 
 void ristretto255_precomputed_scalarmul (
-    point_t out,
+    point_t *out,
     const precomputed_s *table,
-    const scalar_t scalar
+    const scalar_t *scalar
 ) {
     int i;
     unsigned j,k;
     const unsigned int n = COMBS_N, t = COMBS_T, s = COMBS_S;
 
     scalar_t scalar1x;
-    ristretto255_scalar_add(scalar1x, scalar, precomputed_scalarmul_adjustment);
-    ristretto255_scalar_halve(scalar1x,scalar1x);
+    ristretto255_scalar_add(&scalar1x, scalar, &precomputed_scalarmul_adjustment);
+    ristretto255_scalar_halve(&scalar1x,&scalar1x);
 
     niels_t ni;
 
@@ -908,7 +889,7 @@ void ristretto255_precomputed_scalarmul (
             for (k=0; k<t; k++) {
                 unsigned int bit = i + s*(k + j*t);
                 if (bit < SCALAR_BITS) {
-                    tab |= (scalar1x->limb[bit/WBITS] >> (bit%WBITS) & 1) << k;
+                    tab |= (scalar1x.limb[bit/WBITS] >> (bit%WBITS) & 1) << k;
                 }
             }
 
@@ -916,25 +897,25 @@ void ristretto255_precomputed_scalarmul (
             tab ^= invert;
             tab &= (1<<(t-1)) - 1;
 
-            constant_time_lookup_niels(ni, &table->table[j<<(t-1)], 1<<(t-1), tab);
+            constant_time_lookup_niels(&ni, &table->table[j<<(t-1)], 1<<(t-1), tab);
 
-            cond_neg_niels(ni, invert);
+            cond_neg_niels(&ni, invert);
             if ((i!=(int)s-1)||j) {
-                add_niels_to_pt(out, ni, j==n-1 && i);
+                add_niels_to_pt(out, &ni, j==n-1 && i);
             } else {
-                niels_to_pt(out, ni);
+                niels_to_pt(out, &ni);
             }
         }
     }
 
-    ristretto_bzero(ni,sizeof(ni));
-    ristretto_bzero(scalar1x,sizeof(scalar1x));
+    ristretto_bzero(&ni,sizeof(ni));
+    ristretto_bzero(&scalar1x,sizeof(scalar1x));
 }
 
 void ristretto255_point_cond_sel (
-    point_t out,
-    const point_t a,
-    const point_t b,
+    point_t *out,
+    const point_t *a,
+    const point_t *b,
     ristretto_bool_t pick_b
 ) {
     constant_time_select(out,a,b,sizeof(point_t),bool_to_mask(pick_b),0);
@@ -944,17 +925,17 @@ void ristretto255_point_cond_sel (
 ristretto_error_t ristretto255_direct_scalarmul (
     uint8_t scaled[SER_BYTES],
     const uint8_t base[SER_BYTES],
-    const scalar_t scalar,
+    const scalar_t *scalar,
     ristretto_bool_t allow_identity,
     ristretto_bool_t short_circuit
 ) {
     point_t basep;
-    ristretto_error_t succ = ristretto255_point_decode(basep, base, allow_identity);
+    ristretto_error_t succ = ristretto255_point_decode(&basep, base, allow_identity);
     if (short_circuit && succ != RISTRETTO_SUCCESS) return succ;
-    ristretto255_point_cond_sel(basep, ristretto255_point_base, basep, succ);
-    ristretto255_point_scalarmul(basep, basep, scalar);
-    ristretto255_point_encode(scaled, basep);
-    ristretto255_point_destroy(basep);
+    ristretto255_point_cond_sel(&basep, &ristretto255_point_base, &basep, succ);
+    ristretto255_point_scalarmul(&basep, &basep, scalar);
+    ristretto255_point_encode(scaled, &basep);
+    ristretto255_point_destroy(&basep);
     return succ;
 }
 
@@ -968,7 +949,7 @@ struct smvt_control {
 
 static int recode_wnaf (
     struct smvt_control *control, /* [nbits/(table_bits+1) + 3] */
-    const scalar_t scalar,
+    const scalar_t *scalar,
     unsigned int table_bits
 ) {
     unsigned int table_size = SCALAR_BITS/(table_bits+1) + 3;
@@ -1038,54 +1019,54 @@ uint32_t __inline ctz(uint32_t value)
 static void
 prepare_wnaf_table(
     pniels_t *output,
-    const point_t working,
+    const point_t *working,
     unsigned int tbits
 ) {
     point_t tmp;
     int i;
-    pt_to_pniels(output[0], working);
+    pt_to_pniels(&output[0], working);
 
     if (tbits == 0) return;
 
-    ristretto255_point_double(tmp,working);
+    ristretto255_point_double(&tmp,working);
     pniels_t twop;
-    pt_to_pniels(twop, tmp);
+    pt_to_pniels(&twop, &tmp);
 
-    add_pniels_to_pt(tmp, output[0],0);
-    pt_to_pniels(output[1], tmp);
+    add_pniels_to_pt(&tmp, &output[0],0);
+    pt_to_pniels(&output[1], &tmp);
 
     for (i=2; i < 1<<tbits; i++) {
-        add_pniels_to_pt(tmp, twop,0);
-        pt_to_pniels(output[i], tmp);
+        add_pniels_to_pt(&tmp, &twop,0);
+        pt_to_pniels(&output[i], &tmp);
     }
 
-    ristretto255_point_destroy(tmp);
-    ristretto_bzero(twop,sizeof(twop));
+    ristretto255_point_destroy(&tmp);
+    ristretto_bzero(&twop,sizeof(twop));
 }
 
-extern const gf ristretto255_precomputed_wnaf_as_fe[];
+extern const gf_25519_t *ristretto255_precomputed_wnaf_as_fe[];
 static const niels_t *ristretto255_wnaf_base = (const niels_t *)ristretto255_precomputed_wnaf_as_fe;
 const size_t ristretto255_sizeof_precomputed_wnafs
     = sizeof(niels_t)<<RISTRETTO_WNAF_FIXED_TABLE_BITS;
 
 void ristretto255_precompute_wnafs (
     niels_t out[1<<RISTRETTO_WNAF_FIXED_TABLE_BITS],
-    const point_t base
+    const point_t *base
 );
 
 void ristretto255_precompute_wnafs (
     niels_t out[1<<RISTRETTO_WNAF_FIXED_TABLE_BITS],
-    const point_t base
+    const point_t *base
 ) {
     pniels_t tmp[1<<RISTRETTO_WNAF_FIXED_TABLE_BITS];
-    gf zs[1<<RISTRETTO_WNAF_FIXED_TABLE_BITS], zis[1<<RISTRETTO_WNAF_FIXED_TABLE_BITS];
+    gf_25519_t zs[1<<RISTRETTO_WNAF_FIXED_TABLE_BITS], zis[1<<RISTRETTO_WNAF_FIXED_TABLE_BITS];
     int i;
     prepare_wnaf_table(tmp,base,RISTRETTO_WNAF_FIXED_TABLE_BITS);
     for (i=0; i<1<<RISTRETTO_WNAF_FIXED_TABLE_BITS; i++) {
-        memcpy(out[i], tmp[i]->n, sizeof(niels_t));
-        gf_copy(zs[i], tmp[i]->z);
+        memcpy(&out[i], &tmp[i].n, sizeof(niels_t));
+        gf_copy(&zs[i], &tmp[i].z);
     }
-    batch_normalize_niels(out, (const gf *)zs, zis, 1<<RISTRETTO_WNAF_FIXED_TABLE_BITS);
+    batch_normalize_niels(out, zs, zis, 1<<RISTRETTO_WNAF_FIXED_TABLE_BITS);
 
     ristretto_bzero(tmp,sizeof(tmp));
     ristretto_bzero(zs,sizeof(zs));
@@ -1093,10 +1074,10 @@ void ristretto255_precompute_wnafs (
 }
 
 void ristretto255_base_double_scalarmul_non_secret (
-    point_t combo,
-    const scalar_t scalar1,
-    const point_t base2,
-    const scalar_t scalar2
+    point_t *combo,
+    const scalar_t *scalar1,
+    const point_t *base2,
+    const scalar_t *scalar2
 ) {
     const int table_bits_var = RISTRETTO_WNAF_VAR_TABLE_BITS,
         table_bits_pre = RISTRETTO_WNAF_FIXED_TABLE_BITS;
@@ -1112,18 +1093,18 @@ void ristretto255_base_double_scalarmul_non_secret (
     int contp=0, contv=0, i = control_var[0].power;
 
     if (i < 0) {
-        ristretto255_point_copy(combo, ristretto255_point_identity);
+        ristretto255_point_copy(combo, &ristretto255_point_identity);
         return;
     } else if (i > control_pre[0].power) {
-        pniels_to_pt(combo, precmp_var[control_var[0].addend >> 1]);
+        pniels_to_pt(combo, &precmp_var[control_var[0].addend >> 1]);
         contv++;
     } else if (i == control_pre[0].power && i >=0 ) {
-        pniels_to_pt(combo, precmp_var[control_var[0].addend >> 1]);
-        add_niels_to_pt(combo, ristretto255_wnaf_base[control_pre[0].addend >> 1], i);
+        pniels_to_pt(combo, &precmp_var[control_var[0].addend >> 1]);
+        add_niels_to_pt(combo, &ristretto255_wnaf_base[control_pre[0].addend >> 1], i);
         contv++; contp++;
     } else {
         i = control_pre[0].power;
-        niels_to_pt(combo, ristretto255_wnaf_base[control_pre[0].addend >> 1]);
+        niels_to_pt(combo, &ristretto255_wnaf_base[control_pre[0].addend >> 1]);
         contp++;
     }
 
@@ -1135,9 +1116,9 @@ void ristretto255_base_double_scalarmul_non_secret (
             assert(control_var[contv].addend);
 
             if (control_var[contv].addend > 0) {
-                add_pniels_to_pt(combo, precmp_var[control_var[contv].addend >> 1], i&&!cp);
+                add_pniels_to_pt(combo, &precmp_var[control_var[contv].addend >> 1], i&&!cp);
             } else {
-                sub_pniels_from_pt(combo, precmp_var[(-control_var[contv].addend) >> 1], i&&!cp);
+                sub_pniels_from_pt(combo, &precmp_var[(-control_var[contv].addend) >> 1], i&&!cp);
             }
             contv++;
         }
@@ -1146,25 +1127,25 @@ void ristretto255_base_double_scalarmul_non_secret (
             assert(control_pre[contp].addend);
 
             if (control_pre[contp].addend > 0) {
-                add_niels_to_pt(combo, ristretto255_wnaf_base[control_pre[contp].addend >> 1], i);
+                add_niels_to_pt(combo, &ristretto255_wnaf_base[control_pre[contp].addend >> 1], i);
             } else {
-                sub_niels_from_pt(combo, ristretto255_wnaf_base[(-control_pre[contp].addend) >> 1], i);
+                sub_niels_from_pt(combo, &ristretto255_wnaf_base[(-control_pre[contp].addend) >> 1], i);
             }
             contp++;
         }
     }
 
     /* This function is non-secret, but whatever this is cheap. */
-    ristretto_bzero(control_var,sizeof(control_var));
-    ristretto_bzero(control_pre,sizeof(control_pre));
-    ristretto_bzero(precmp_var,sizeof(precmp_var));
+    ristretto_bzero(&control_var,sizeof(control_var));
+    ristretto_bzero(&control_pre,sizeof(control_pre));
+    ristretto_bzero(&precmp_var,sizeof(precmp_var));
 
     assert(contv == ncb_var); (void)ncb_var;
     assert(contp == ncb_pre); (void)ncb_pre;
 }
 
 void ristretto255_point_destroy (
-    point_t point
+    point_t *point
 ) {
     ristretto_bzero(point, sizeof(point_t));
 }

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -18,24 +18,24 @@
 #define scalar_t ristretto255_scalar_t
 
 static const ristretto_word_t MONTGOMERY_FACTOR = (ristretto_word_t)0xd2b51da312547e1bull;
-static const scalar_t sc_p = {{{
+static const scalar_t sc_p = {{
     SC_LIMB(0x5812631a5cf5d3ed), SC_LIMB(0x14def9dea2f79cd6), SC_LIMB(0x0000000000000000), SC_LIMB(0x1000000000000000)
-}}}, sc_r2 = {{{
+}}, sc_r2 = {{
     SC_LIMB(0xa40611e3449c0f01), SC_LIMB(0xd00e1ba768859347), SC_LIMB(0xceec73d217f5be65), SC_LIMB(0x0399411b7c309a3d)
-}}};
+}};
 
 #define WBITS RISTRETTO_WORD_BITS /* NB this may be different from ARCH_WORD_BITS */
 
-const scalar_t ristretto255_scalar_one = {{{1}}}, ristretto255_scalar_zero = {{{0}}};
+const scalar_t ristretto255_scalar_one = {{1}}, ristretto255_scalar_zero = {{0}};
 
 /** {extra,accum} - sub +? p
  * Must have extra <= 1
  */
 static RISTRETTO_NOINLINE void sc_subx(
-    scalar_t out,
+    scalar_t *out,
     const ristretto_word_t accum[SCALAR_LIMBS],
-    const scalar_t sub,
-    const scalar_t p,
+    const scalar_t *sub,
+    const scalar_t *p,
     ristretto_word_t extra
 ) {
     ristretto_dsword_t chain = 0;
@@ -56,9 +56,9 @@ static RISTRETTO_NOINLINE void sc_subx(
 }
 
 static RISTRETTO_NOINLINE void sc_montmul (
-    scalar_t out,
-    const scalar_t a,
-    const scalar_t b
+    scalar_t *out,
+    const scalar_t *a,
+    const scalar_t *b
 ) {
     unsigned int i,j;
     ristretto_word_t accum[SCALAR_LIMBS+1] = {0};
@@ -78,7 +78,7 @@ static RISTRETTO_NOINLINE void sc_montmul (
 
         mand = accum[0] * MONTGOMERY_FACTOR;
         chain = 0;
-        mier = sc_p->limb;
+        mier = sc_p.limb;
         for (j=0; j<SCALAR_LIMBS; j++) {
             chain += (ristretto_dword_t)mand*mier[j] + accum[j];
             if (j) accum[j-1] = chain;
@@ -90,26 +90,26 @@ static RISTRETTO_NOINLINE void sc_montmul (
         hi_carry = chain >> WBITS;
     }
 
-    sc_subx(out, accum, sc_p, sc_p, hi_carry);
+    sc_subx(out, accum, &sc_p, &sc_p, hi_carry);
 }
 
 void ristretto255_scalar_mul (
-    scalar_t out,
-    const scalar_t a,
-    const scalar_t b
+    scalar_t *out,
+    const scalar_t *a,
+    const scalar_t *b
 ) {
     sc_montmul(out,a,b);
-    sc_montmul(out,out,sc_r2);
+    sc_montmul(out,out,&sc_r2);
 }
 
 /* PERF: could implement this */
-static RISTRETTO_INLINE void sc_montsqr (scalar_t out, const scalar_t a) {
+static RISTRETTO_INLINE void sc_montsqr (scalar_t *out, const scalar_t *a) {
     sc_montmul(out,a,a);
 }
 
 ristretto_error_t ristretto255_scalar_invert (
-    scalar_t out,
-    const scalar_t a
+    scalar_t *out,
+    const scalar_t *a
 ) {
     /* Fermat's little theorem, sliding window.
      * Sliding window is fine here because the modulus isn't secret.
@@ -119,12 +119,12 @@ ristretto_error_t ristretto255_scalar_invert (
     const int LAST = (1<<SCALAR_WINDOW_BITS)-1;
 
     /* Precompute precmp = [a^1,a^3,...] */
-    sc_montmul(precmp[0],a,sc_r2);
-    if (LAST > 0) sc_montmul(precmp[LAST],precmp[0],precmp[0]);
+    sc_montmul(&precmp[0],a,&sc_r2);
+    if (LAST > 0) sc_montmul(&precmp[LAST],&precmp[0],&precmp[0]);
 
     int i;
     for (i=1; i<=LAST; i++) {
-        sc_montmul(precmp[i],precmp[i-1],precmp[LAST]);
+        sc_montmul(&precmp[i],&precmp[i-1],&precmp[LAST]);
     }
 
     /* Sliding window */
@@ -133,7 +133,7 @@ ristretto_error_t ristretto255_scalar_invert (
 
         if (started) sc_montsqr(out,out);
 
-        ristretto_word_t w = (i>=0) ? sc_p->limb[i/WBITS] : 0;
+        ristretto_word_t w = (i>=0) ? sc_p.limb[i/WBITS] : 0;
         if (i >= 0 && i<WBITS) {
             assert(w >= 2);
             w-=2;
@@ -148,9 +148,9 @@ ristretto_error_t ristretto255_scalar_invert (
 
         if (trailing > 0 && (trailing & ((1<<SCALAR_WINDOW_BITS)-1)) == 0) {
             if (started) {
-                sc_montmul(out,out,precmp[trailing>>(SCALAR_WINDOW_BITS+1)]);
+                sc_montmul(out,out,&precmp[trailing>>(SCALAR_WINDOW_BITS+1)]);
             } else {
-                ristretto255_scalar_copy(out,precmp[trailing>>(SCALAR_WINDOW_BITS+1)]);
+                ristretto255_scalar_copy(out,&precmp[trailing>>(SCALAR_WINDOW_BITS+1)]);
                 started = 1;
             }
             trailing = 0;
@@ -162,23 +162,23 @@ ristretto_error_t ristretto255_scalar_invert (
     assert(trailing==0);
 
     /* Demontgomerize */
-    sc_montmul(out,out,ristretto255_scalar_one);
-    ristretto_bzero(precmp, sizeof(precmp));
-    return ristretto_succeed_if(~ristretto255_scalar_eq(out,ristretto255_scalar_zero));
+    sc_montmul(out,out,&ristretto255_scalar_one);
+    ristretto_bzero(&precmp, sizeof(precmp));
+    return ristretto_succeed_if(~ristretto255_scalar_eq(out,&ristretto255_scalar_zero));
 }
 
 void ristretto255_scalar_sub (
-    scalar_t out,
-    const scalar_t a,
-    const scalar_t b
+    scalar_t *out,
+    const scalar_t *a,
+    const scalar_t *b
 ) {
-    sc_subx(out, a->limb, b, sc_p, 0);
+    sc_subx(out, a->limb, b, &sc_p, 0);
 }
 
 void ristretto255_scalar_add (
-    scalar_t out,
-    const scalar_t a,
-    const scalar_t b
+    scalar_t *out,
+    const scalar_t *a,
+    const scalar_t *b
 ) {
     ristretto_dword_t chain = 0;
     unsigned int i;
@@ -187,12 +187,12 @@ void ristretto255_scalar_add (
         out->limb[i] = chain;
         chain >>= WBITS;
     }
-    sc_subx(out, out->limb, sc_p, sc_p, chain);
+    sc_subx(out, out->limb, &sc_p, &sc_p, chain);
 }
 
 void
 ristretto255_scalar_set_unsigned (
-    scalar_t out,
+    scalar_t *out,
     uint64_t w
 ) {
     memset(out,0,sizeof(scalar_t));
@@ -207,8 +207,8 @@ ristretto255_scalar_set_unsigned (
 
 ristretto_bool_t
 ristretto255_scalar_eq (
-    const scalar_t a,
-    const scalar_t b
+    const scalar_t *a,
+    const scalar_t *b
 ) {
     ristretto_word_t diff = 0;
     unsigned int i;
@@ -219,7 +219,7 @@ ristretto255_scalar_eq (
 }
 
 static RISTRETTO_INLINE void scalar_decode_short (
-    scalar_t s,
+    scalar_t *s,
     const unsigned char *ser,
     unsigned int nbytes
 ) {
@@ -234,35 +234,35 @@ static RISTRETTO_INLINE void scalar_decode_short (
 }
 
 ristretto_error_t ristretto255_scalar_decode(
-    scalar_t s,
+    scalar_t *s,
     const unsigned char ser[SCALAR_SER_BYTES]
 ) {
     unsigned int i;
     scalar_decode_short(s, ser, SCALAR_SER_BYTES);
     ristretto_dsword_t accum = 0;
     for (i=0; i<SCALAR_LIMBS; i++) {
-        accum = (accum + s->limb[i] - sc_p->limb[i]) >> WBITS;
+        accum = (accum + s->limb[i] - sc_p.limb[i]) >> WBITS;
     }
     /* Here accum == 0 or -1 */
 
-    ristretto255_scalar_mul(s,s,ristretto255_scalar_one); /* ham-handed reduce */
+    ristretto255_scalar_mul(s,s,&ristretto255_scalar_one); /* ham-handed reduce */
 
     return ristretto_succeed_if(~word_is_zero(accum));
 }
 
 void ristretto255_scalar_destroy (
-    scalar_t scalar
+    scalar_t *scalar
 ) {
     ristretto_bzero(scalar, sizeof(scalar_t));
 }
 
 void ristretto255_scalar_decode_long(
-    scalar_t s,
+    scalar_t *s,
     const unsigned char *ser,
     size_t ser_len
 ) {
     if (ser_len == 0) {
-        ristretto255_scalar_copy(s, ristretto255_scalar_zero);
+        ristretto255_scalar_copy(s, &ristretto255_scalar_zero);
         return;
     }
 
@@ -272,31 +272,31 @@ void ristretto255_scalar_decode_long(
     i = ser_len - (ser_len%SCALAR_SER_BYTES);
     if (i==ser_len) i -= SCALAR_SER_BYTES;
 
-    scalar_decode_short(t1, &ser[i], ser_len-i);
+    scalar_decode_short(&t1, &ser[i], ser_len-i);
 
     if (ser_len == sizeof(scalar_t)) {
         assert(i==0);
         /* ham-handed reduce */
-        ristretto255_scalar_mul(s,t1,ristretto255_scalar_one);
-        ristretto255_scalar_destroy(t1);
+        ristretto255_scalar_mul(s,&t1,&ristretto255_scalar_one);
+        ristretto255_scalar_destroy(&t1);
         return;
     }
 
     while (i) {
         i -= SCALAR_SER_BYTES;
-        sc_montmul(t1,t1,sc_r2);
-        ignore_result( ristretto255_scalar_decode(t2, ser+i) );
-        ristretto255_scalar_add(t1, t1, t2);
+        sc_montmul(&t1,&t1,&sc_r2);
+        ignore_result( ristretto255_scalar_decode(&t2, ser+i) );
+        ristretto255_scalar_add(&t1, &t1, &t2);
     }
 
-    ristretto255_scalar_copy(s, t1);
-    ristretto255_scalar_destroy(t1);
-    ristretto255_scalar_destroy(t2);
+    ristretto255_scalar_copy(s, &t1);
+    ristretto255_scalar_destroy(&t1);
+    ristretto255_scalar_destroy(&t2);
 }
 
 void ristretto255_scalar_encode(
     unsigned char ser[SCALAR_SER_BYTES],
-    const scalar_t s
+    const scalar_t *s
 ) {
     unsigned int i,j,k=0;
     for (i=0; i<SCALAR_LIMBS; i++) {
@@ -307,23 +307,23 @@ void ristretto255_scalar_encode(
 }
 
 void ristretto255_scalar_cond_sel (
-    scalar_t out,
-    const scalar_t a,
-    const scalar_t b,
+    scalar_t *out,
+    const scalar_t *a,
+    const scalar_t *b,
     ristretto_bool_t pick_b
 ) {
     constant_time_select(out,a,b,sizeof(scalar_t),bool_to_mask(pick_b),sizeof(out->limb[0]));
 }
 
 void ristretto255_scalar_halve (
-    scalar_t out,
-    const scalar_t a
+    scalar_t *out,
+    const scalar_t *a
 ) {
     ristretto_word_t mask = -(a->limb[0] & 1);
     ristretto_dword_t chain = 0;
     unsigned int i;
     for (i=0; i<SCALAR_LIMBS; i++) {
-        chain = (chain + a->limb[i]) + (sc_p->limb[i] & mask);
+        chain = (chain + a->limb[i]) + (sc_p.limb[i] & mask);
         out->limb[i] = chain;
         chain >>= RISTRETTO_WORD_BITS;
     }

--- a/tests/src/constants.rs
+++ b/tests/src/constants.rs
@@ -1,39 +1,41 @@
-use libristretto255_sys::{gf_25519_s, ristretto255_point_s};
+use libristretto255_sys::{gf_25519_t, ristretto255_point_t};
 
-macro_rules! gf25519 {
-    ($l0:expr, $l1:expr, $l2:expr, $l3:expr, $l4:expr) => {
-        [gf_25519_s {
-            limb: [$l0, $l1, $l2, $l3, $l4],
+macro_rules! field_literal {
+    ($($elem:tt)+) => {
+        gf_25519_t {
+            limb: [$($elem)+],
             #[cfg(target_pointer_width = "64")]
             __bindgen_padding_0: [0, 0, 0],
-        }]
+        }
     };
 }
 
-pub const EIGHT_TORSION: [ristretto255_point_s; 8] = [
-    ristretto255_point_s {
-        x: gf25519!(0, 0, 0, 0, 0),
-        y: gf25519!(1, 0, 0, 0, 0),
-        z: gf25519!(1, 0, 0, 0, 0),
-        t: gf25519!(0, 0, 0, 0, 0),
+/// Eight torsion table taken directly from curve25519-dalek
+/// TODO: this is probably completely bogus and only works on 64-bit architectures
+pub const EIGHT_TORSION: [ristretto255_point_t; 8] = [
+    ristretto255_point_t {
+        x: field_literal!(0, 0, 0, 0, 0),
+        y: field_literal!(1, 0, 0, 0, 0),
+        z: field_literal!(1, 0, 0, 0, 0),
+        t: field_literal!(0, 0, 0, 0, 0),
     },
-    ristretto255_point_s {
-        x: gf25519!(
+    ristretto255_point_t {
+        x: field_literal!(
             358744748052810,
             1691584618240980,
             977650209285361,
             1429865912637724,
             560044844278676
         ),
-        y: gf25519!(
+        y: field_literal!(
             84926274344903,
             473620666599931,
             365590438845504,
             1028470286882429,
             2146499180330972
         ),
-        z: gf25519!(1, 0, 0, 0, 0),
-        t: gf25519!(
+        z: field_literal!(1, 0, 0, 0, 0),
+        t: field_literal!(
             1448326834587521,
             1857896831960481,
             1093722731865333,
@@ -41,35 +43,35 @@ pub const EIGHT_TORSION: [ristretto255_point_s; 8] = [
             1915505153018406
         ),
     },
-    ristretto255_point_s {
-        x: gf25519!(
+    ristretto255_point_t {
+        x: field_literal!(
             533094393274173,
             2016890930128738,
             18285341111199,
             134597186663265,
             1486323764102114
         ),
-        y: gf25519!(0, 0, 0, 0, 0),
-        z: gf25519!(1, 0, 0, 0, 0),
-        t: gf25519!(0, 0, 0, 0, 0),
+        y: field_literal!(0, 0, 0, 0, 0),
+        z: field_literal!(1, 0, 0, 0, 0),
+        t: field_literal!(0, 0, 0, 0, 0),
     },
-    ristretto255_point_s {
-        x: gf25519!(
+    ristretto255_point_t {
+        x: field_literal!(
             358744748052810,
             1691584618240980,
             977650209285361,
             1429865912637724,
             560044844278676
         ),
-        y: gf25519!(
+        y: field_literal!(
             2166873539340326,
             1778179147085316,
             1886209374839743,
             1223329526802818,
             105300633354275
         ),
-        z: gf25519!(1, 0, 0, 0, 0),
-        t: gf25519!(
+        z: field_literal!(1, 0, 0, 0, 0),
+        t: field_literal!(
             803472979097708,
             393902981724766,
             1158077081819914,
@@ -77,35 +79,35 @@ pub const EIGHT_TORSION: [ristretto255_point_s; 8] = [
             336294660666841
         ),
     },
-    ristretto255_point_s {
-        x: gf25519!(0, 0, 0, 0, 0),
-        y: gf25519!(
+    ristretto255_point_t {
+        x: field_literal!(0, 0, 0, 0, 0),
+        y: field_literal!(
             2251799813685228,
             2251799813685247,
             2251799813685247,
             2251799813685247,
             2251799813685247
         ),
-        z: gf25519!(1, 0, 0, 0, 0),
-        t: gf25519!(0, 0, 0, 0, 0),
+        z: field_literal!(1, 0, 0, 0, 0),
+        t: field_literal!(0, 0, 0, 0, 0),
     },
-    ristretto255_point_s {
-        x: gf25519!(
+    ristretto255_point_t {
+        x: field_literal!(
             1893055065632419,
             560215195444267,
             1274149604399886,
             821933901047523,
             1691754969406571
         ),
-        y: gf25519!(
+        y: field_literal!(
             2166873539340326,
             1778179147085316,
             1886209374839743,
             1223329526802818,
             105300633354275
         ),
-        z: gf25519!(1, 0, 0, 0, 0),
-        t: gf25519!(
+        z: field_literal!(1, 0, 0, 0, 0),
+        t: field_literal!(
             1448326834587521,
             1857896831960481,
             1093722731865333,
@@ -113,35 +115,35 @@ pub const EIGHT_TORSION: [ristretto255_point_s; 8] = [
             1915505153018406
         ),
     },
-    ristretto255_point_s {
-        x: gf25519!(
+    ristretto255_point_t {
+        x: field_literal!(
             1718705420411056,
             234908883556509,
             2233514472574048,
             2117202627021982,
             765476049583133
         ),
-        y: gf25519!(0, 0, 0, 0, 0),
-        z: gf25519!(1, 0, 0, 0, 0),
-        t: gf25519!(0, 0, 0, 0, 0),
+        y: field_literal!(0, 0, 0, 0, 0),
+        z: field_literal!(1, 0, 0, 0, 0),
+        t: field_literal!(0, 0, 0, 0, 0),
     },
-    ristretto255_point_s {
-        x: gf25519!(
+    ristretto255_point_t {
+        x: field_literal!(
             1893055065632419,
             560215195444267,
             1274149604399886,
             821933901047523,
             1691754969406571
         ),
-        y: gf25519!(
+        y: field_literal!(
             84926274344903,
             473620666599931,
             365590438845504,
             1028470286882429,
             2146499180330972
         ),
-        z: gf25519!(1, 0, 0, 0, 0),
-        t: gf25519!(
+        z: field_literal!(1, 0, 0, 0, 0),
+        t: field_literal!(
             803472979097708,
             393902981724766,
             1158077081819914,


### PR DESCRIPTION
This library (i.e. libdecaf) originally used a "neat trick" in C to define "unified" struct and pointer types which work in either context by always referencing structs as 1-element arrays. This eliminated the need to add `&` to all operands in the point and field arithmetic code, which was visually a lot less noisy.

Some more discussion of this approach here:

https://twitter.com/syncomo/status/1029366966924890113

The main drawback of this approach is trying to build external bindings to it. Though array and pointer types are the same in C, making things convenient there, in the generated bindings for other languages, such as Rust's bindgen, this approach adds a superfluous array around
everything.

Worse, since Rust bindgen can't reason about the interior mutability of arrays, it breaks const correctness in the generated binding, since Rust assumes all of the array interiors are mutable.

This change switches to doing the more normal/"ugly" thing and uses ordinary structs and pointers, with the typedefs all aliased to the structs. It adds annoying `&`s all over the arithmetic, but the
generated bindings are simple and clean, without superfluous `[1]`s.

**NOTE**: Lots of find/replace and hand edits, and still no tests! It's entirely possible something was botched in this process. (The next step after this will definitely be tests but I didn't want to write them until the binding is const-correct)